### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -1,5 +1,8 @@
 name: Build Check
 
+permissions:
+  contents: read
+
 on:
   # Trigger on pull requests to main branch
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/KSS-IT-Committee/2026-event-week-top/security/code-scanning/1](https://github.com/KSS-IT-Committee/2026-event-week-top/security/code-scanning/1)

Add an explicit workflow-level `permissions` block near the top of `.github/workflows/build-check.yml` so all jobs inherit least-privilege token scopes.  
For this workflow, the best minimal setting is:

- `contents: read`

This supports `actions/checkout@v4` and keeps token access tightly scoped. No job-specific override is needed since all jobs are read-only checks (build/lint/summary) and do not require write permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
