### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -12,6 +12,9 @@ on:
   # Allow manual trigger from Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build and Type Check


### PR DESCRIPTION
Potential fix for [https://github.com/KSS-IT-Committee/2026-event-week-top/security/code-scanning/2](https://github.com/KSS-IT-Committee/2026-event-week-top/security/code-scanning/2)

Add an explicit top-level `permissions` block in `.github/workflows/build-check.yml` so all jobs inherit least-privilege defaults.  
Best fix without changing functionality: add:

- `permissions:`
  - `contents: read`

Place it after the `on:` triggers (or near the top before `jobs:`). This satisfies the CodeQL requirement and documents intended token access for all jobs (`build`, `lint`, `checks-summary`) without altering workflow behavior.

No imports, methods, or dependency changes are needed—just YAML configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
