### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -1,8 +1,5 @@
 name: Build Check
 
-permissions:
-  contents: read
-
 on:
   # Trigger on pull requests to main branch
   pull_request:

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -12,6 +12,10 @@ on:
   # Allow manual trigger from Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   build:
     name: Build and Type Check


### PR DESCRIPTION
Potential fix for [https://github.com/KSS-IT-Committee/2026-event-week-top/security/code-scanning/3](https://github.com/KSS-IT-Committee/2026-event-week-top/security/code-scanning/3)

Add an explicit `permissions` block at the workflow root (top level) so it applies to all jobs (`build`, `lint`, and `checks-summary`) unless overridden.  
For this workflow, the least-privilege baseline that preserves existing behavior is:

- `contents: read` (needed for checkout and repository read access)
- `actions: read` (safe for interacting with workflow actions metadata)

This keeps functionality unchanged while preventing accidental write scopes from inherited defaults.

**Where to change:** `.github/workflows/build-check.yml`, near the top-level keys (`name`, `on`, `jobs`), insert `permissions` between `on` and `jobs` (or directly after `name`/`on` at root level).

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
