### PR TITLE
fixing our schools name to the official one

### DIFF
--- a/app/components/footer.tsx
+++ b/app/components/footer.tsx
@@ -4,7 +4,7 @@ export function defaultFooter() {
   return (
     <footer className={styles.footer}>
       <h1 className={styles.footerTheme}>行事週間2026 青、薫る</h1>
-      <p>© 2026 小石川中等教育学校</p>
+      <p>© 2026 東京都立小石川中等教育学校</p>
       <p>行事運営委員会・IT委員会</p>
     </footer>
   );


### PR DESCRIPTION
It was used to be written as 小石川中等教育学校,
but the official name is now 東京都立小石川中等教育学校.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the school name displayed in the footer for accuracy.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KSS-IT-Committee/2026-event-week-top/pull/33)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->