### PR TITLE
Disable gtag on PR preview deployments

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -30,17 +30,24 @@ export default function RootLayout({
       className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
     >
       <head>
-        {/* Google tag (gtag.js) */}
-        <Script
-          src="https://www.googletagmanager.com/gtag/js?id=G-STVFHMQS05"
-          strategy="afterInteractive"
-        />
-        <Script id="google-analytics" strategy="afterInteractive">
-          {`window.dataLayer = window.dataLayer || [];
+        {/* Google tag (gtag.js) — skipped on PR preview deployments.
+            IS_PR_PREVIEW is injected at runtime by the deploy infra and read
+            here server-side, so it must NOT be NEXT_PUBLIC_ (those inline at
+            build time). */}
+        {process.env.IS_PR_PREVIEW !== "true" && (
+          <>
+            <Script
+              src="https://www.googletagmanager.com/gtag/js?id=G-STVFHMQS05"
+              strategy="afterInteractive"
+            />
+            <Script id="google-analytics" strategy="afterInteractive">
+              {`window.dataLayer = window.dataLayer || [];
 function gtag(){dataLayer.push(arguments);}
 gtag('js', new Date());
 gtag('config', 'G-STVFHMQS05');`}
-        </Script>
+            </Script>
+          </>
+        )}
       </head>
       <body className="min-h-full flex flex-col">{children}</body>
     </html>

--- a/content/changelog/0074-changelog.json
+++ b/content/changelog/0074-changelog.json
@@ -1,0 +1,7 @@
+{
+  "title": "プレビュー時のGtagの無効化",
+  "description": "ページのプレビューの時に、Google Analyticsのタグが無効化されました。これによるページの変更はありません。",
+  "credits": [
+    "@rotarymars"
+  ]
+}

--- a/content/changelog/0074-changelog.json
+++ b/content/changelog/0074-changelog.json
@@ -1,7 +1,5 @@
 {
   "title": "プレビュー時のGtagの無効化",
   "description": "ページのプレビューの時に、Google Analyticsのタグが無効化されました。これによるページの変更はありません。",
-  "credits": [
-    "@rotarymars"
-  ]
+  "credits": ["@rotarymars"]
 }


### PR DESCRIPTION
## What

Wrap the Google Analytics gtag scripts in `app/layout.tsx` in a server-side `IS_PR_PREVIEW` guard so **PR preview deployments stop sending hits to the production GA property**.

## Why this works

`app/layout.tsx` is a Server Component, so `process.env.IS_PR_PREVIEW` is read at request time. The deploy infra injects `IS_PR_PREVIEW=true` into PR preview containers only (via `docker run -e` in `sync-pr-previews.sh`), so production/main is unaffected.

The flag is deliberately **not** `NEXT_PUBLIC_`-prefixed: Next.js inlines `NEXT_PUBLIC_*` at build time, which would freeze the value and make the runtime injection a no-op.

## Companion change

Requires the matching env injection in the ansible repo (`roles/apps/templates/sync-pr-previews.sh.j2`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized analytics tracking to exclude PR preview deployments, ensuring production analytics data remains accurate and unaffected by preview environment traffic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->