### PR TITLE
changed the preview script to build from local when there's no tag

### DIFF
--- a/scripts/preview.sh
+++ b/scripts/preview.sh
@@ -1,22 +1,32 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-TAG="${1:-latest}"
 PROJECT="top-preview"
-COMPOSE_FILE="$(dirname "$0")/../docker-compose.preview.yml"
+REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+COMPOSE_FILE="${REPO_DIR}/docker-compose.preview.yml"
 
-remote_url=$(git -C "$(dirname "$0")/.." remote get-url origin)
+remote_url=$(git -C "$REPO_DIR" remote get-url origin)
 slug=${remote_url#*github.com[:/]}
 slug=${slug%.git}
 slug=$(printf '%s' "$slug" | tr '[:upper:]' '[:lower:]')
 
 export IMAGE_SLUG="$slug"
+
+if [ "$#" -ge 1 ]; then
+  # A tag was given: pull the published preview image (e.g. pr-123, sha-abc, latest).
+  TAG="$1"
+  IMAGE="ghcr.io/${slug}/preview:${TAG}"
+  echo "Pulling ${IMAGE}"
+  docker pull "$IMAGE"
+else
+  # No tag: build the image from the current working tree (local preview).
+  TAG="local"
+  IMAGE="ghcr.io/${slug}/preview:${TAG}"
+  echo "Building ${IMAGE} from ${REPO_DIR}"
+  docker build -t "$IMAGE" "$REPO_DIR"
+fi
+
 export TAG
-
-IMAGE="ghcr.io/${slug}/preview:${TAG}"
-
-echo "Pulling ${IMAGE}"
-docker pull "$IMAGE"
 
 cleanup() {
   docker compose -p "$PROJECT" -f "$COMPOSE_FILE" down --remove-orphans >/dev/null 2>&1 || true


### PR DESCRIPTION
It used to pull the latest tag from ghcr, but that's kind of wired.
I've decided to build from local if there's no tag, which is more normal and better for dev.