### PR TITLE
Fix failing production deploy: render news posts to JSON at build time

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -14,3 +14,4 @@ Dockerfile
 docker-compose*.yml
 scripts
 !scripts/build-changelog.mjs
+!scripts/build-posts.mjs

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -67,6 +67,10 @@ jobs:
         # this during `npm run build` below; that's fine and idempotent.
         run: npm run changelog
 
+      - name: Generate posts artifact
+        # Same deal for `@/lib/posts.generated.json` (news pages).
+        run: npm run posts
+
       - name: Run TypeScript compiler check
         run: npx tsc --noEmit
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,10 @@ jobs:
         # under shallow clone, but that's fine; we only need the file present.
         run: npm run changelog
 
+      - name: Generate posts artifact
+        # Same deal for `@/lib/posts.generated.json` (news pages).
+        run: npm run posts
+
       - name: Run TypeScript compiler
         run: npx tsc --noEmit
 

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ next-env.d.ts
 
 # changelog generated artifact (built by scripts/build-changelog.mjs)
 /lib/changelog.generated.json
+
+# posts generated artifact (built by scripts/build-posts.mjs)
+/lib/posts.generated.json

--- a/app/news/newsData.ts
+++ b/app/news/newsData.ts
@@ -1,6 +1,4 @@
-import fs from "fs";
-import matter from "gray-matter";
-import path from "path";
+import posts from "@/lib/posts.generated.json";
 
 export interface NewsItem {
   id: string;
@@ -11,22 +9,16 @@ export interface NewsItem {
 }
 
 export function getNews(): NewsItem[] {
-  const newsDir = path.join(process.cwd(), "content/posts");
-  const files = fs.readdirSync(newsDir).filter((file) => file.endsWith(".md"));
-
-  const news = files.map((file) => {
-    const filePath = path.join(newsDir, file);
-    const fileContent = fs.readFileSync(filePath, "utf-8");
-    const { data, content } = matter(fileContent);
-
-    return {
-      id: data.id,
-      title: data.title,
-      date: new Date(data.date).toISOString().split("T")[0],
-      tag: data.tag,
-      content,
-    } satisfies NewsItem;
-  });
+  const news = posts.map(
+    (post) =>
+      ({
+        id: post.id,
+        title: post.title,
+        date: post.date.split("T")[0],
+        tag: post.tag,
+        content: post.content,
+      }) satisfies NewsItem,
+  );
 
   return news.sort((a, b) => (a.date < b.date ? 1 : -1));
 }

--- a/content/changelog/0121-changelog.json
+++ b/content/changelog/0121-changelog.json
@@ -1,0 +1,5 @@
+{
+  "title": "ページのバグの修正",
+  "description": "最新版のページが表示されないバグを修正しました。",
+  "credits": ["@rotarymars"]
+}

--- a/lib/posts.ts
+++ b/lib/posts.ts
@@ -1,8 +1,4 @@
-import fs from "fs";
-import matter from "gray-matter";
-import path from "path";
-import { remark } from "remark";
-import html from "remark-html";
+import posts from "./posts.generated.json";
 
 type Post = {
   id: string;
@@ -11,44 +7,26 @@ type Post = {
   date: string;
 };
 
-const postsDirectory = path.join(process.cwd(), "content/posts");
-
 export function getAllPosts() {
-  const fileNames = fs
-    .readdirSync(postsDirectory)
-    .filter((file) => file.endsWith(".md"));
-
-  return fileNames.map((fileName) => {
-    const id = fileName.replace(/\.md$/, "");
-    const fullPath = path.join(postsDirectory, fileName);
-    const fileContents = fs.readFileSync(fullPath, "utf8");
-
-    const { data } = matter(fileContents);
-
-    return {
-      id,
-      ...data,
-    };
-  });
+  return posts.map((post) => ({
+    id: post.slug,
+    title: post.title,
+    date: post.date,
+    tag: post.tag,
+  }));
 }
 
 export async function getPostById(id: string): Promise<Post> {
-  const fullPath = path.join(postsDirectory, `${id}.md`);
-  const fileContents = fs.readFileSync(fullPath, "utf8");
+  const post = posts.find((p) => p.slug === id);
 
-  const { data, content } = matter(fileContents);
-
-  if (!data.title || !data.date) {
-    throw new Error(`Post ${id} missing required frontmatter: title or date`);
+  if (!post) {
+    throw new Error(`Post ${id} not found`);
   }
 
-  const processedContent = await remark().use(html).process(content);
-  const contentHtml = processedContent.toString();
-
   return {
-    id,
-    contentHtml,
-    title: data.title,
-    date: data.date,
+    id: post.slug,
+    contentHtml: post.contentHtml,
+    title: post.title,
+    date: post.date,
   };
 }

--- a/package.json
+++ b/package.json
@@ -4,9 +4,10 @@
   "private": true,
   "scripts": {
     "changelog": "node scripts/build-changelog.mjs",
-    "predev": "npm run changelog",
+    "posts": "node scripts/build-posts.mjs",
+    "predev": "npm run changelog && npm run posts",
     "dev": "next dev",
-    "prebuild": "npm run changelog",
+    "prebuild": "npm run changelog && npm run posts",
     "build": "next build",
     "start": "next start",
     "lint": "eslint .",

--- a/scripts/build-posts.mjs
+++ b/scripts/build-posts.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+// Renders content/posts/*.md (frontmatter + markdown body) into a single
+// lib/posts.generated.json at build time. The Docker runner stage ships only
+// the build output — not content/ — so the news pages must never read the
+// markdown from disk at runtime; they statically import this artifact instead.
+
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import matter from "gray-matter";
+import { remark } from "remark";
+import html from "remark-html";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const SOURCE_DIR = join(repoRoot, "content", "posts");
+const OUT_FILE = join(repoRoot, "lib", "posts.generated.json");
+
+const log = (msg) => console.log(`[posts] ${msg}`);
+
+function writeArtifact(posts) {
+  mkdirSync(dirname(OUT_FILE), { recursive: true });
+  writeFileSync(OUT_FILE, JSON.stringify(posts, null, 2) + "\n");
+}
+
+if (!existsSync(SOURCE_DIR)) {
+  writeArtifact([]);
+  log(`no sources at ${SOURCE_DIR}; wrote empty artifact`);
+  process.exit(0);
+}
+
+const files = readdirSync(SOURCE_DIR)
+  .filter((f) => f.endsWith(".md"))
+  .sort();
+
+const posts = await Promise.all(
+  files.map(async (file) => {
+    const raw = readFileSync(join(SOURCE_DIR, file), "utf8");
+    const { data, content } = matter(raw);
+    if (!data.title || !data.date) {
+      throw new Error(
+        `[posts] ${file}: missing required frontmatter: title or date`,
+      );
+    }
+    const slug = file.replace(/\.md$/, "");
+    const contentHtml = String(await remark().use(html).process(content));
+    return {
+      slug,
+      id: typeof data.id === "string" ? data.id : slug,
+      title: data.title,
+      date: new Date(data.date).toISOString(),
+      tag: typeof data.tag === "string" ? data.tag : "",
+      content,
+      contentHtml,
+    };
+  }),
+);
+
+writeArtifact(posts);
+log(
+  `wrote ${posts.length} post${posts.length === 1 ? "" : "s"} to ${OUT_FILE}`,
+);


### PR DESCRIPTION
## Problem

Every main deploy since the news component merge (#72) has been failing on the VPS. The poll loop pulls the new image, but the health check times out and `deploy-app.sh` rolls back — production is still serving `sha-b68d0a7` (pre-news).

Root cause: `getNews()` / `getAllPosts()` read `content/posts/*.md` from disk **at request time** (and `app/page.tsx` calls `getNews()` at module scope), but the Dockerfile's runner stage never copies `content/` into the final image. Every render of `/` crashed with:

```
⨯ Error: ENOENT: no such file or directory, scandir '/app/content/posts'
```

CI passes because the builder stage has the full checkout — the breakage only appears in the trimmed runtime image.

## Fix

Posts are build-time data, so this mirrors the existing changelog pipeline instead of shipping `content/` in the image:

- `scripts/build-posts.mjs` (run via `predev` / `prebuild`) parses the frontmatter and renders the markdown to HTML, emitting `lib/posts.generated.json` (gitignored).
- `lib/posts.ts` and `app/news/newsData.ts` statically import the artifact — no runtime `fs` access, no Dockerfile / ansible-template change needed.
- CI typecheck job generates the artifact before `tsc` (same as the changelog one); `.dockerignore` whitelists the new script.

Behavior is unchanged: same `getNews` / `getAllPosts` / `getPostById` signatures, same date formats, markdown→HTML still via remark.

## Verification

Built the production image locally from this branch and ran it (no `content/` inside, just like prod):

- `/`, `/news/list`, `/news/news1` all return **200**
- zero `ENOENT` in container logs
- `tsc --noEmit`, lint, format:check, `next build` all pass

Once merged, the server poll loop will pick up the new sha automatically — no manual server action needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Posts and news data are now pre-generated at build time, improving runtime performance.

* **Chores**
  * Updated build and CI workflows to generate post artifacts during the build process.
  * Modified ignore configurations to include new generated artifact files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->