### PR TITLE
Harden staff-account check + make classOf portable

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,5 +1,6 @@
 import type { NextRequest } from "next/server";
 
+import { isClassName } from "@/db/schema";
 import { type ChatMessage, runChat } from "@/lib/chat";
 import { checkRateLimit } from "@/lib/rate-limit";
 import { getCurrentUser } from "@/lib/session";
@@ -121,8 +122,12 @@ export async function POST(request: NextRequest) {
   }
 
   // The caller's class, derived from the session — drives class-private tool
-  // scoping. null for non-students (teachers / committee / admin).
-  const viewer = { className: classOf(user.username) };
+  // scoping. null for non-students (teachers / committee / admin). classOf
+  // returns a validated class string; isClassName narrows it to ClassName.
+  const rawClass = classOf(user.username);
+  const viewer = {
+    className: rawClass !== null && isClassName(rawClass) ? rawClass : null,
+  };
 
   const encoder = new TextEncoder();
   const stream = new ReadableStream<Uint8Array>({

--- a/app/components/AuthGuard/index.tsx
+++ b/app/components/AuthGuard/index.tsx
@@ -11,7 +11,7 @@ type Role = (typeof ROLENAMES)[number];
 // Inlined here so this guard stays self-contained; DRY it up once
 // user-category.ts is on main.
 const STUDENT_RE = /^[1-6][A-D]\d{2}$/; // 1A01 … 6D40
-const TEACHER_RE = /^k/; // k-prefixed staff accounts
+const TEACHER_RE = /^k\d{7}$/; // staff accounts: k + 7 digits, e.g. k0959176
 
 function isInternal(username: string): boolean {
   return STUDENT_RE.test(username) || TEACHER_RE.test(username);

--- a/lib/user-category.ts
+++ b/lib/user-category.ts
@@ -1,5 +1,5 @@
 const STUDENT_RE = /^[1-6][A-D]\d{2}$/; // 1A01 … 6D40
-const TEACHER_RE = /^k/; // k-prefixed staff accounts
+const TEACHER_RE = /^k\d{7}$/; // staff accounts: k + 7 digits, e.g. k0959176
 
 export function isInternal(username: string): boolean {
   return STUDENT_RE.test(username) || TEACHER_RE.test(username);

--- a/lib/user-category.ts
+++ b/lib/user-category.ts
@@ -1,22 +1,15 @@
-import { type ClassName, isClassName } from "@/db/schema";
-
-export type category = ["school", "external"];
-
-// Student logins are `<class><seat>` e.g. 1A01 .. 6D40; staff are k-prefixed.
-const STUDENT_RE = /^[1-6][A-D]\d{2}$/;
-const TEACHER_RE = /^k/;
+const STUDENT_RE = /^[1-6][A-D]\d{2}$/; // 1A01 … 6D40
+const TEACHER_RE = /^k/; // k-prefixed staff accounts
 
 export function isInternal(username: string): boolean {
   return STUDENT_RE.test(username) || TEACHER_RE.test(username);
 }
 
 /**
- * The class a username belongs to (e.g. "1A01" -> "1A"), or null for any
- * non-student account (teachers, committee, admin). Used to scope class-private
- * data — deductions and announcements — to the logged-in student's own class.
+ * The class code a username belongs to (e.g. "1A01" -> "1A"), or null for a
+ * non-student account (teachers, committee, admin). The STUDENT_RE match
+ * guarantees the two-char prefix is a valid class (1A..6D).
  */
-export function classOf(username: string): ClassName | null {
-  if (!STUDENT_RE.test(username)) return null;
-  const className = username.slice(0, 2);
-  return isClassName(className) ? className : null;
+export function classOf(username: string): string | null {
+  return STUDENT_RE.test(username) ? username.slice(0, 2) : null;
 }


### PR DESCRIPTION
Follow-up commits on the chat branch, pushed after #145 merged:

- **`make classOf self-contained`** — `classOf` no longer imports from `@/db/schema`; the `STUDENT_RE` match already guarantees the two-char prefix is a valid class, so it returns `string | null` and `lib/user-category.ts` stays import-free and **byte-identical across all four apps**. The chat route narrows the result to `ClassName` via `isClassName`.
- **`harden internal-account check`** — constrain `TEACHER_RE` from `/^k/` (which matched any `k`-prefixed string, e.g. `kiosk`) to `/^k\d{7}$/`, the real staff-account format from `2026-account-generator` (e.g. `k0959176`). Applied to both `lib/user-category.ts` and AuthGuard's inlined copy. Flagged by automated security review.

The same `classOf` helper + regex hardening landed in the other three apps via KSS-IT-Committee/2026-sousakuten-info#118, KSS-IT-Committee/2026-sousakuten-equipment-management#121, and KSS-IT-Committee/2026-taiikusai-top#56.

🤖 Generated with [Claude Code](https://claude.com/claude-code)