### PR TITLE
Add role-admin scripts (grant/revoke/list users.roles)

### DIFF
--- a/scripts/grant-role.sh
+++ b/scripts/grant-role.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Grant a role to one or more users in the shared `appdata` DB. Run on the VPS,
+# where the `postgres` container lives (Postgres has no host port). Append-only
+# and idempotent: existing roles are kept, and re-running is a no-op.
+#
+#   ./grant-role.sh <role> <username> [username...]
+#   ./grant-role.sh Sousakuten 3B12 4A05 k0959176
+
+ROLES=(IT Sousakuten Taiikusai)
+
+die() {
+  echo "error: $1" >&2
+  echo "usage: $0 <role> <username> [username...]   (roles: ${ROLES[*]})" >&2
+  exit 2
+}
+
+[ "$#" -ge 2 ] || die "expected a role and at least one username"
+role="$1"
+shift
+
+# Validate the role against the enum so a typo can't reach SQL.
+printf '%s\n' "${ROLES[@]}" | grep -qxF "$role" || die "unknown role '$role'"
+
+# Build a quoted, comma-separated username list. Reject anything that isn't a
+# plain account id (class codes like 3B12, staff like k0959176) so a value can't
+# break out of the SQL string.
+list=""
+for u in "$@"; do
+  [[ "$u" =~ ^[A-Za-z0-9]+$ ]] || die "invalid username '$u'"
+  list+="${list:+, }'${u}'"
+done
+
+docker exec postgres psql -U postgres -d appdata -c \
+  "UPDATE users SET roles = array_append(roles, '${role}') WHERE username IN (${list}) AND NOT ('${role}' = ANY(roles));"
+
+# Show the resulting rows so the grant is easy to eyeball.
+docker exec postgres psql -U postgres -d appdata -c \
+  "SELECT username, roles FROM users WHERE username IN (${list}) ORDER BY username;"

--- a/scripts/revoke-role.sh
+++ b/scripts/revoke-role.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Revoke a role from one or more users in the shared `appdata` DB. Run on the
+# VPS, where the `postgres` container lives (Postgres has no host port). Other
+# roles on each user are left untouched; re-running is a no-op.
+#
+#   ./revoke-role.sh <role> <username> [username...]
+#   ./revoke-role.sh Sousakuten 3B12 4A05
+
+ROLES=(IT Sousakuten Taiikusai)
+
+die() {
+  echo "error: $1" >&2
+  echo "usage: $0 <role> <username> [username...]   (roles: ${ROLES[*]})" >&2
+  exit 2
+}
+
+[ "$#" -ge 2 ] || die "expected a role and at least one username"
+role="$1"
+shift
+
+printf '%s\n' "${ROLES[@]}" | grep -qxF "$role" || die "unknown role '$role'"
+
+list=""
+for u in "$@"; do
+  [[ "$u" =~ ^[A-Za-z0-9]+$ ]] || die "invalid username '$u'"
+  list+="${list:+, }'${u}'"
+done
+
+docker exec postgres psql -U postgres -d appdata -c \
+  "UPDATE users SET roles = array_remove(roles, '${role}') WHERE username IN (${list});"
+
+docker exec postgres psql -U postgres -d appdata -c \
+  "SELECT username, roles FROM users WHERE username IN (${list}) ORDER BY username;"

--- a/scripts/users-by-role.sh
+++ b/scripts/users-by-role.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# List the users holding a role in the shared `appdata` DB. Run on the VPS,
+# where the `postgres` container lives (Postgres has no host port).
+#
+#   ./users-by-role.sh <role>
+#   ./users-by-role.sh Sousakuten
+
+ROLES=(IT Sousakuten Taiikusai)
+
+die() {
+  echo "error: $1" >&2
+  echo "usage: $0 <role>   (roles: ${ROLES[*]})" >&2
+  exit 2
+}
+
+[ "$#" -eq 1 ] || die "expected exactly one role"
+role="$1"
+
+printf '%s\n' "${ROLES[@]}" | grep -qxF "$role" || die "unknown role '$role'"
+
+docker exec postgres psql -U postgres -d appdata -c \
+  "SELECT username, roles FROM users WHERE '${role}' = ANY(roles) ORDER BY username;"


### PR DESCRIPTION
## What

Three ops helpers under `scripts/`, in the style of `has-loggedin.sh` / `session-valid-user.sh`, for managing the `users.roles` column in the shared `appdata` DB. Run on the VPS against the `postgres` container (Postgres has no host port).

| Script | Purpose |
|---|---|
| `grant-role.sh <role> <user...>` | grant a role — append-only, idempotent (keeps existing roles, re-run is a no-op) |
| `revoke-role.sh <role> <user...>` | remove a role, leaving the user's other roles intact |
| `users-by-role.sh <role>` | list everyone holding a role |

Example: `./grant-role.sh Sousakuten 3B12 4A05 k0959176`

## Safety

- The role is validated against the enum (`IT` / `Sousakuten` / `Taiikusai`) and each username against `^[A-Za-z0-9]+$`, so a typo or stray value can't reach SQL (injection attempts are rejected before any query runs).
- Grant/revoke print the affected rows afterward so the change is easy to eyeball.

Verified: `bash -n` clean; dry-run (docker stubbed) confirms correct SQL generation and rejection of bad roles / usernames / missing args.

🤖 Generated with [Claude Code](https://claude.com/claude-code)