### PR TITLE
fix(announcements): don't treat class-less announcements as global

### DIFF
--- a/db/getAnnouncements.ts
+++ b/db/getAnnouncements.ts
@@ -62,11 +62,11 @@ export async function getAnnouncements(
 
   let list = [...byId.values()];
   if (className) {
-    // Scope to the class: announcements targeting it, plus untargeted ones
-    // (no class = a general/global announcement everyone should see).
-    list = list.filter(
-      (a) => a.classes.length === 0 || a.classes.includes(className),
-    );
+    // Scope to the class: only announcements explicitly targeting it. A
+    // class-less announcement is NOT treated as global here — sousakuten-info
+    // (which owns and writes announcements) inner-joins the link table and
+    // never surfaces a class-less row, so this keeps both apps in agreement.
+    list = list.filter((a) => a.classes.includes(className));
   }
   return list.slice(0, limit);
 }


### PR DESCRIPTION
getAnnouncements (used by the /chat assistant tool) returned announcements with no announcement_classes link in EVERY class's results via the classes.length === 0 branch, contradicting its own docstring and diverging from sousakuten-info, which owns/writes announcements and inner-joins the link table (never surfacing class-less rows). Drop the general branch so a class filter returns only announcements explicitly targeting that class. Latent today (the only writer, sousakuten-info addAnnouncement, requires >=1 class) but removes the cross-app semantic mismatch on the shared tables.