### PR TITLE
fix(login): throttle repeated attempts per username

### DIFF
--- a/app/login/actions.ts
+++ b/app/login/actions.ts
@@ -6,6 +6,7 @@ import { redirect } from "next/navigation";
 
 import { getUserByUsername } from "@/db/getUserByUsername";
 import { setUserLoggedIn } from "@/db/setUserLoggedIn";
+import { checkRateLimit } from "@/lib/rate-limit";
 import { createSession, invalidateSession } from "@/lib/session";
 import {
   SESSION_COOKIE_NAME,
@@ -25,6 +26,14 @@ export type LogoutFormState = {
 // timing). Hash of a random throwaway string, cost 12 like the real ones.
 const DUMMY_PASSWORD_HASH =
   "$2b$12$b9knPwSWvdYaEpu/5ogc1esBjm6AIkZxstMde5jGCUCTMizZEUogO";
+
+// Per-account login throttle, checked before the cost-12 bcrypt.compare.
+// Keyed by username, NOT IP: the school logs in en masse from a shared NAT,
+// so a per-IP cap would lock out legitimate students. This slows targeted
+// guessing of a single account; the unauthenticated CPU-exhaustion vector is
+// for nginx limit_req at the edge. Per-process only (see lib/rate-limit.ts).
+const LOGIN_MAX_ATTEMPTS = 10;
+const LOGIN_RATE_WINDOW_MS = 60_000;
 
 // Students type credentials from printed cards, often through a Japanese
 // IME — fold full-width characters back to ASCII and trim stray whitespace.
@@ -84,6 +93,17 @@ export async function loginAction(
   const password = normalizeInput(formData.get("password"));
   if (username === "" || password === "") {
     return { error: "ユーザー名とパスワードを入力してください。" };
+  }
+
+  const attempt = checkRateLimit(
+    `login:${username}`,
+    LOGIN_MAX_ATTEMPTS,
+    LOGIN_RATE_WINDOW_MS,
+  );
+  if (!attempt.ok) {
+    return {
+      error: "試行回数が多すぎます。しばらくしてからもう一度お試しください。",
+    };
   }
 
   const user = await getUserByUsername(username);


### PR DESCRIPTION
## What
Add a per-username rate limit to `loginAction` (10/min, reusing the existing `lib/rate-limit.ts`), checked **before** the cost-12 `bcrypt.compare`.

## Why
`loginAction` ran `getUserByUsername` + `bcrypt.compare` on every POST with no throttle (audit `AUDIT-2026-06-17.md` → M3): unthrottled online guessing of a known account, plus a CPU-exhaustion vector.

## Design notes
- **Keyed by username, not IP.** The school logs in en masse from a shared NAT, so a per-IP cap would lock out legitimate students. Per-username throttling slows targeted guessing without that risk.
- The unauthenticated **CPU-exhaustion** axis is best handled by an nginx `limit_req` (with burst) at the edge — a separate change in `2026-server-ansible`. This PR is the app-side guardrail.
- The limiter is per-process (per-instance) — see `lib/rate-limit.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)