### PR TITLE
fix(chat): fail over to next model after a mid-stream 429/503

### DIFF
--- a/app/components/Chat/index.tsx
+++ b/app/components/Chat/index.tsx
@@ -2,6 +2,8 @@
 
 import { useEffect, useRef, useState } from "react";
 
+import { CHAT_RESET_SIGNAL } from "@/lib/chat-protocol";
+
 import styles from "./Chat.module.css";
 
 type Message = {
@@ -73,7 +75,18 @@ export function Chat() {
         setMessages((prev) => {
           const next = [...prev];
           const last = next[next.length - 1];
-          next[next.length - 1] = { ...last, text: last.text + delta };
+          // A RESET marker means the server is re-answering on another model
+          // (the previous one failed mid-stream). Discard the partial shown so
+          // far for this bubble and keep only what follows the marker. This
+          // clears the ENTIRE bubble — including any visible preamble from an
+          // earlier tool iteration — which is fine: the re-answer is
+          // self-contained and prior turns remain in the model's own history.
+          const text = delta.includes(CHAT_RESET_SIGNAL)
+            ? delta.slice(
+                delta.lastIndexOf(CHAT_RESET_SIGNAL) + CHAT_RESET_SIGNAL.length,
+              )
+            : last.text + delta;
+          next[next.length - 1] = { ...last, text };
           return next;
         });
       };

--- a/lib/chat-protocol.ts
+++ b/lib/chat-protocol.ts
@@ -1,0 +1,17 @@
+// Shared wire-protocol constant for the /chat plain-text stream. This module is
+// deliberately NOT `server-only`: it is imported by both the server streamer
+// (lib/chat.ts) and the browser chat component (app/components/Chat), so the two
+// sides agree on the same marker.
+//
+// When a model fails (429/503) AFTER it has already streamed part of an answer,
+// the server can't silently fail over — the user has seen partial text. Instead
+// it emits this RESET marker into the stream and re-answers on the next model;
+// the client, on seeing the marker, DISCARDS everything shown so far for the
+// current assistant message and renders the re-generated answer from scratch, so
+// nothing is duplicated or interleaved.
+//
+// It is a single Private-Use-Area code point (U+E000): models never emit PUA
+// characters, and it round-trips through UTF-8 / nginx intact, so it can't
+// collide with real answer text the way an ASCII sentinel could. Built via
+// fromCharCode so the source stays plain ASCII (no invisible glyph to review).
+export const CHAT_RESET_SIGNAL = String.fromCharCode(0xe000);

--- a/lib/chat.ts
+++ b/lib/chat.ts
@@ -2,6 +2,7 @@ import "server-only";
 
 import type { Content, FunctionCall, Part } from "@google/genai";
 
+import { CHAT_RESET_SIGNAL } from "@/lib/chat-protocol";
 import {
   chatToolDeclarations,
   type ChatViewer,
@@ -116,8 +117,9 @@ export async function* runChat(
     // Try this turn on up to MAX_MODEL_ATTEMPTS distinct models. A thrown error
     // (most likely a per-model 429/503) or an empty response (no text, no tool
     // call) counts as "failed to return something" and fails over to the next
-    // model — but only while nothing has streamed to the user yet this turn, so
-    // a partially-streamed answer is never duplicated or interleaved.
+    // model. When the failure lands AFTER partial text has streamed, we emit
+    // CHAT_RESET_SIGNAL so the client clears that partial before the next model
+    // re-answers — so a model switch is never duplicated or interleaved on screen.
     let streamedThisTurn = false;
     let gotResponse = false;
     let lastError: unknown;
@@ -162,9 +164,18 @@ export async function* runChat(
         if (isModelUnavailableError(error)) {
           noteModelUnavailable(modelOrder[a], error);
         }
-        // Don't retry a client-aborted request, and don't retry once we've
-        // already streamed text (the user has seen partial output).
-        if (signal?.aborted || streamedThisTurn) throw error;
+        // A client-aborted request is dead — stop immediately.
+        if (signal?.aborted) throw error;
+        if (streamedThisTurn) {
+          // We've already streamed partial text from this now-failed attempt.
+          // For a transient model-unavailable error, tell the client to DISCARD
+          // that partial (CHAT_RESET_SIGNAL) and re-answer this turn from scratch
+          // on the next model — no duplicated text. Any other error (a real bug,
+          // not a transient limit) is surfaced as before.
+          if (!isModelUnavailableError(error)) throw error;
+          yield CHAT_RESET_SIGNAL;
+          streamedThisTurn = false;
+        }
         // otherwise fall through and try the next model
       }
     }


### PR DESCRIPTION
When a chat model failed (rate-limited / overloaded) AFTER it had already streamed partial text, runChat rethrew and the user saw a truncated answer plus a generic error — there was no failover, because partial output was already on screen and re-streaming would duplicate it.

Now, on a transient model-unavailable error mid-stream, the server emits a RESET marker into the stream and re-answers on the next model. The client discards the partial answer on the marker and renders the re-generated one, so a model switch is never duplicated or interleaved on screen.

- lib/chat-protocol.ts: shared, client-safe RESET marker (U+E000)
- lib/chat.ts: emit RESET + fail over instead of rethrowing once streamed
- app/components/Chat: discard the partial bubble on the RESET marker


Co-authored by: claude

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed chat response handling when the server needs to retry mid-stream. Partial messages are now properly cleared when the server regenerates an answer, preventing text duplication and ensuring smooth recovery from model failovers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->