### PR TITLE
ci: revert preview-image to the native-arm build

### DIFF
--- a/.github/workflows/preview-image.yml
+++ b/.github/workflows/preview-image.yml
@@ -16,31 +16,41 @@ concurrency:
   group: preview-image-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}/preview
+
 jobs:
-  # Single job builds BOTH arches via QEMU emulation and pushes one multi-arch
-  # manifest. Runs on one runner (no native arm64 runner needed), so it works on
-  # the Forgejo dind runner as well as GitHub.
-  #
-  # Registry is chosen by host: GHCR when this runs on GitHub, the Forgejo
-  # instance's own container registry when it runs on Forgejo. Auth uses the
-  # platform's automatic Actions token in both cases.
-  build-and-push:
-    name: Build and push preview image (amd64 + arm64 via QEMU)
-    runs-on: ubuntu-latest
+  # Each architecture builds in its own job, in parallel, on a native runner
+  # (no QEMU). Both push the SAME image by digest only — no tags yet — so the
+  # two halves never race over a shared tag. Wall-clock is the slower arch,
+  # not the sum of both.
+  build:
+    name: Build ${{ matrix.platform }}
+    runs-on: ${{ matrix.runner }}
+
+    strategy:
+      # Don't let a failed arch cancel the other; we still want the digest of
+      # whichever finished so the merge can report what's available.
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
 
     steps:
-      - name: Resolve registry + image name
+      - name: Prepare
+        # PLATFORM_PAIR (e.g. linux-amd64) names the per-arch digest artifact
+        # and scopes the build cache. IMAGE is the registry path lowercased —
+        # the org is mixed-case (KSS-IT-Committee) but GHCR rejects uppercase
+        # repository names, and unlike metadata-action's tag output this name
+        # is handed straight to the daemon.
         run: |
-          host="${GITHUB_SERVER_URL#http://}"; host="${host#https://}"
-          if [ "$host" = "github.com" ]; then
-            registry="ghcr.io"
-          else
-            # Forgejo's built-in container registry shares the instance host.
-            registry="$host"
-          fi
-          image="${registry}/${GITHUB_REPOSITORY}/preview"
-          echo "REGISTRY=${registry}" >> "$GITHUB_ENV"
-          # Registries reject uppercase repository names (the org is mixed-case).
+          platform="${{ matrix.platform }}"
+          echo "PLATFORM_PAIR=${platform//\//-}" >> "$GITHUB_ENV"
+          image="${REGISTRY}/${IMAGE_NAME}"
           echo "IMAGE=${image,,}" >> "$GITHUB_ENV"
 
       - name: Checkout
@@ -49,6 +59,8 @@ jobs:
           # Full history so scripts/build-changelog.mjs can resolve per-file
           # add-dates via `git log --diff-filter=A --follow`.
           fetch-depth: 0
+          # GHCR auth uses an explicit secrets.GITHUB_TOKEN in the
+          # docker/login step; no need to leave it in .git/config too.
           persist-credentials: false
 
       - name: Setup Node.js
@@ -61,20 +73,16 @@ jobs:
         run: npm ci
 
       - name: Generate changelog artifact
-        # Must run on the runner — .git is excluded from the Docker build context
-        # by .dockerignore, so the script can't resolve dates inside the image.
-        # The resulting lib/changelog.generated.json is picked up by `COPY . .`.
+        # Must run on the runner — .git is excluded from the Docker build
+        # context by .dockerignore, so the script can't resolve dates inside
+        # the image. The resulting lib/changelog.generated.json is picked up
+        # by `COPY . .` in the builder stage.
         run: npm run changelog
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
-        with:
-          platforms: arm64
-
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
-      - name: Log in to the container registry
+      - name: Log in to GHCR
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ env.REGISTRY }}
@@ -85,22 +93,86 @@ jobs:
         id: meta
         uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
-          images: ${{ env.IMAGE }}
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # Push the image content without any tag; the merge job attaches the
+          # tags once both digests exist.
+          outputs: type=image,name=${{ env.IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          # Per-arch cache scope so the two parallel jobs don't clobber each
+          # other's gha cache.
+          cache-from: type=gha,scope=${{ env.PLATFORM_PAIR }}
+          cache-to: type=gha,mode=max,scope=${{ env.PLATFORM_PAIR }}
+
+      - name: Export digest
+        run: |
+          mkdir -p "${RUNNER_TEMP}/digests"
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${RUNNER_TEMP}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # Once both arch jobs have pushed their content, assemble a single
+  # multi-arch manifest under the real tags (pr-N / sha-xxx / latest / main).
+  # Consumers (vvps, ansible) keep pulling the same tag and get the right arch.
+  merge:
+    name: Merge manifest
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - name: Prepare
+        run: |
+          image="${REGISTRY}/${IMAGE_NAME}"
+          echo "IMAGE=${image,,}" >> "$GITHUB_ENV"
+
+      - name: Download digests
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      - name: Log in to GHCR
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract image metadata
+        id: meta
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=ref,event=pr
             type=raw,value=latest,enable={{is_default_branch}}
             type=raw,value=main,enable={{is_default_branch}}
             type=sha,prefix=sha-,format=short
 
-      - name: Build and push (amd64 + arm64)
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
-        with:
-          context: .
-          push: true
-          platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          # Registry-backed cache works on both GHCR and the Forgejo registry
-          # (the GitHub Actions `type=gha` cache is unreliable on Forgejo).
-          cache-from: type=registry,ref=${{ env.IMAGE }}:buildcache
-          cache-to: type=registry,ref=${{ env.IMAGE }}:buildcache,mode=max
+      - name: Create multi-arch manifest
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf "${IMAGE}@sha256:%s " *)
+
+      - name: Inspect manifest
+        run: |
+          docker buildx imagetools inspect "${IMAGE}:${{ steps.meta.outputs.version }}"


### PR DESCRIPTION
Reverts the QEMU + host-aware-registry change to `preview-image.yml` — we decided not to self-host Forgejo, so this restores the original native-arm multi-runner image build (verified byte-identical to the pre-change file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the image build workflow to use parallel native architecture builds, improving build efficiency and deployment speed while maintaining multi-architecture image support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->