### PR TITLE
adding the method to change password

### DIFF
--- a/app/login/ChangePasswordForm.tsx
+++ b/app/login/ChangePasswordForm.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useActionState } from "react";
+
+import { changePasswordAction, type ChangePasswordFormState } from "./actions";
+import styles from "./login.module.css";
+
+const INITIAL_STATE: ChangePasswordFormState = { error: null, success: false };
+
+type ChangePasswordFormProps = {
+  // The app the user came from (the `next` carried by AccountNav). Offered as a
+  // return link once the change succeeds, so a flow started on another app can
+  // go back to it.
+  next?: string;
+};
+
+export function ChangePasswordForm({ next }: ChangePasswordFormProps) {
+  const [state, formAction, isPending] = useActionState(
+    changePasswordAction,
+    INITIAL_STATE,
+  );
+
+  return (
+    <form action={formAction} className={styles.form}>
+      <div className={styles.field}>
+        <label className={styles.label} htmlFor="current-password">
+          現在のパスワード
+        </label>
+        <input
+          id="current-password"
+          className={styles.input}
+          name="currentPassword"
+          type="password"
+          autoComplete="current-password"
+          required
+        />
+      </div>
+      <div className={styles.field}>
+        <label className={styles.label} htmlFor="new-password">
+          新しいパスワード
+        </label>
+        <input
+          id="new-password"
+          className={styles.input}
+          name="newPassword"
+          type="password"
+          autoComplete="new-password"
+          minLength={8}
+          required
+        />
+      </div>
+      <div className={styles.field}>
+        <label className={styles.label} htmlFor="confirm-password">
+          新しいパスワード（確認）
+        </label>
+        <input
+          id="confirm-password"
+          className={styles.input}
+          name="confirmPassword"
+          type="password"
+          autoComplete="new-password"
+          minLength={8}
+          required
+        />
+      </div>
+      {state.error !== null && (
+        <p className={styles.error} role="alert">
+          {state.error}
+        </p>
+      )}
+      {state.success && (
+        <p className={styles.success} role="status">
+          パスワードを変更しました。他の端末からはログアウトされました。
+        </p>
+      )}
+      {state.success && next !== undefined && (
+        <a className={styles.returnLink} href={next}>
+          元のページに戻る
+        </a>
+      )}
+      <button className={styles.button} type="submit" disabled={isPending}>
+        {isPending ? "変更中…" : "パスワードを変更"}
+      </button>
+    </form>
+  );
+}

--- a/app/login/actions.ts
+++ b/app/login/actions.ts
@@ -8,6 +8,7 @@ import { deleteUserSessions } from "@/db/deleteUserSessions";
 import { getUserByUsername } from "@/db/getUserByUsername";
 import { setUserLoggedIn } from "@/db/setUserLoggedIn";
 import { updateUserPassword } from "@/db/updateUserPassword";
+import { db } from "@/lib/db";
 import { checkRateLimit } from "@/lib/rate-limit";
 import { safeNextPath } from "@/lib/safe-next";
 import {
@@ -219,14 +220,20 @@ export async function changePasswordAction(
 
   // Cost 12 to match the existing seeded hashes (and the login dummy hash).
   const newHash = await bcrypt.hash(newPassword, 12);
-  await updateUserPassword(username, newHash);
 
-  // A password change logs the user out everywhere: drop every session for the
-  // account (shared `sessions` table → all apps), then re-issue one for this
-  // device so the person who just changed it stays logged in here. On a PR
-  // preview the schema-only clone has no rows, so both calls are harmless
-  // no-ops (the verify above already fails closed there).
-  await deleteUserSessions(username);
+  // Write the new hash and revoke every session for the account atomically, so
+  // a partial failure can never leave the new password active while old
+  // sessions still validate. A password change logs the user out everywhere
+  // (shared `sessions` table → all apps). On a PR preview the schema-only clone
+  // has no rows, so both writes are harmless no-ops (the verify above already
+  // fails closed there).
+  await db.transaction(async (tx) => {
+    await updateUserPassword(username, newHash, tx);
+    await deleteUserSessions(username, tx);
+  });
+
+  // Re-issue a session for this device only after the change has committed, so
+  // the person who just changed their password stays logged in here.
   const token = await createSession(username);
   const cookieStore = await cookies();
   cookieStore.set(SESSION_COOKIE_NAME, token, sessionCookieOptions());

--- a/app/login/actions.ts
+++ b/app/login/actions.ts
@@ -4,10 +4,17 @@ import bcrypt from "bcryptjs";
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 
+import { deleteUserSessions } from "@/db/deleteUserSessions";
 import { getUserByUsername } from "@/db/getUserByUsername";
 import { setUserLoggedIn } from "@/db/setUserLoggedIn";
+import { updateUserPassword } from "@/db/updateUserPassword";
 import { checkRateLimit } from "@/lib/rate-limit";
-import { createSession, invalidateSession } from "@/lib/session";
+import { safeNextPath } from "@/lib/safe-next";
+import {
+  createSession,
+  getCurrentUser,
+  invalidateSession,
+} from "@/lib/session";
 import {
   SESSION_COOKIE_NAME,
   sessionCookieOptions,
@@ -19,6 +26,11 @@ export type LoginFormState = {
 
 export type LogoutFormState = {
   error: string | null;
+};
+
+export type ChangePasswordFormState = {
+  error: string | null;
+  success: boolean;
 };
 
 // Compared against when the username doesn't exist, so a login attempt
@@ -40,46 +52,6 @@ const LOGIN_RATE_WINDOW_MS = 60_000;
 function normalizeInput(value: FormDataEntryValue | null): string {
   if (typeof value !== "string") return "";
   return value.normalize("NFKC").trim();
-}
-
-// A satellite app (equipment.2026.kss-it.com, …) sends the user here to log
-// in and wants them back afterwards, so we accept absolute https URLs whose
-// host is in the SESSION_COOKIE_DOMAIN family — and nothing else. The whole
-// `*.2026.kss-it.com` namespace is committee-controlled, so this isn't an
-// open redirect; an unrelated host still falls back to "/".
-function isAllowedReturnHost(host: string): boolean {
-  const domain = process.env.SESSION_COOKIE_DOMAIN;
-  if (!domain) return false;
-  return host === domain || host.endsWith(`.${domain}`);
-}
-
-function safeNextPath(value: FormDataEntryValue | null): string {
-  if (typeof value !== "string") return "/";
-
-  // Same-site relative path. Resolve against a sentinel origin and require it
-  // to survive unchanged: a plain startsWith("/") check isn't enough because
-  // browsers fold "\" to "/", so "/\evil.com" (and control chars, "//evil.com")
-  // resolve to a foreign origin.
-  if (value.startsWith("/")) {
-    try {
-      const url = new URL(value, "https://placeholder.invalid");
-      if (url.origin !== "https://placeholder.invalid") return "/";
-      return url.pathname + url.search + url.hash;
-    } catch {
-      return "/";
-    }
-  }
-
-  // Absolute URL back to a sibling app under the 2026 namespace.
-  try {
-    const url = new URL(value);
-    if (url.protocol === "https:" && isAllowedReturnHost(url.host)) {
-      return url.toString();
-    }
-  } catch {
-    // not a parseable absolute URL — fall through
-  }
-  return "/";
 }
 
 export async function loginAction(
@@ -148,4 +120,116 @@ export async function logoutAction(
   });
 
   redirect(safeNextPath(formData.get("next")));
+}
+
+// Minimum length of a self-chosen password. A floor, not a strength policy —
+// the seeded card passwords are stronger than this; we only stop someone
+// replacing one with something trivially short.
+const PASSWORD_MIN_LENGTH = 8;
+// bcrypt (and bcryptjs) silently truncates its input at 72 *bytes*, so anything
+// past that wouldn't really be part of the password. NFKC-folded Japanese input
+// is multi-byte, so this is a byte cap, not a character cap. Reject rather than
+// store a password whose tail is ignored.
+const PASSWORD_MAX_BYTES = 72;
+
+// Per-account throttle on the cost-12 bcrypt verify, mirroring loginAction.
+const PWCHANGE_MAX_ATTEMPTS = 10;
+const PWCHANGE_RATE_WINDOW_MS = 60_000;
+
+// Change the logged-in user's password. This lives on the shared /login page,
+// so — like the session itself — it works from every app under the namespace:
+// each app's AccountNav links here, the cookie is read with getCurrentUser, and
+// the write lands in the shared `appdata`. A successful change invalidates the
+// user's sessions on *all* apps and re-issues one for this device.
+export async function changePasswordAction(
+  _prevState: ChangePasswordFormState,
+  formData: FormData,
+): Promise<ChangePasswordFormState> {
+  // Self-authorize from the session, NOT from form input: a Server Action is
+  // independently invocable, and the new password must always apply to the
+  // caller's own account. Never read a username from formData here — that would
+  // be a "change anyone's password" hole.
+  const sessionUser = await getCurrentUser();
+  if (sessionUser === null) {
+    return {
+      error: "セッションが無効です。再度ログインしてください。",
+      success: false,
+    };
+  }
+  const { username } = sessionUser;
+
+  // Normalize exactly like loginAction so a password set here is byte-for-byte
+  // what the login form will later submit (NFKC-fold full-width IME input, trim
+  // surrounding whitespace).
+  const currentPassword = normalizeInput(formData.get("currentPassword"));
+  const newPassword = normalizeInput(formData.get("newPassword"));
+  const confirmPassword = normalizeInput(formData.get("confirmPassword"));
+
+  if (currentPassword === "" || newPassword === "" || confirmPassword === "") {
+    return { error: "すべての項目を入力してください。", success: false };
+  }
+  if (newPassword !== confirmPassword) {
+    return { error: "新しいパスワードが一致しません。", success: false };
+  }
+  if (newPassword.length < PASSWORD_MIN_LENGTH) {
+    return {
+      error: `新しいパスワードは${PASSWORD_MIN_LENGTH}文字以上にしてください。`,
+      success: false,
+    };
+  }
+  if (Buffer.byteLength(newPassword, "utf8") > PASSWORD_MAX_BYTES) {
+    return { error: "新しいパスワードが長すぎます。", success: false };
+  }
+  if (newPassword === currentPassword) {
+    return {
+      error: "新しいパスワードが現在のパスワードと異なるものにしてください。",
+      success: false,
+    };
+  }
+
+  const attempt = checkRateLimit(
+    `pwchange:${username}`,
+    PWCHANGE_MAX_ATTEMPTS,
+    PWCHANGE_RATE_WINDOW_MS,
+  );
+  if (!attempt.ok) {
+    return {
+      error: "試行回数が多すぎます。しばらくしてからもう一度お試しください。",
+      success: false,
+    };
+  }
+
+  // Re-verify the current password against the stored hash. SessionUser carries
+  // only { username, roles }, so re-fetch the row for its hash. This stops a
+  // shoulder-surfed or hijacked session from silently resetting the password.
+  const account = await getUserByUsername(username);
+  if (account === null) {
+    return {
+      error: "セッションが無効です。再度ログインしてください。",
+      success: false,
+    };
+  }
+  const isCurrentValid = await bcrypt.compare(
+    currentPassword,
+    account.passwordHash,
+  );
+  if (!isCurrentValid) {
+    return { error: "現在のパスワードが正しくありません。", success: false };
+  }
+
+  // Cost 12 to match the existing seeded hashes (and the login dummy hash).
+  const newHash = await bcrypt.hash(newPassword, 12);
+  await updateUserPassword(username, newHash);
+
+  // A password change logs the user out everywhere: drop every session for the
+  // account (shared `sessions` table → all apps), then re-issue one for this
+  // device so the person who just changed it stays logged in here. On a PR
+  // preview the schema-only clone has no rows, so both calls are harmless
+  // no-ops (the verify above already fails closed there).
+  await deleteUserSessions(username);
+  const token = await createSession(username);
+  const cookieStore = await cookies();
+  cookieStore.set(SESSION_COOKIE_NAME, token, sessionCookieOptions());
+
+  return { error: null, success: true };
 }

--- a/app/login/login.module.css
+++ b/app/login/login.module.css
@@ -27,6 +27,18 @@
   margin-bottom: 24px;
 }
 
+.divider {
+  margin: 28px 0 24px;
+  border: none;
+  border-top: 1px solid color-mix(in oklch, var(--foreground) 12%, transparent);
+}
+
+.subtitle {
+  font-size: 1.15rem;
+  font-weight: 700;
+  margin-bottom: 12px;
+}
+
 .form {
   display: flex;
   flex-direction: column;
@@ -64,10 +76,26 @@
   color: #d4380d;
 }
 
+.success {
+  font-size: 0.9rem;
+  color: #237804;
+}
+
+.returnLink {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #0b69eb;
+}
+
 @media (prefers-color-scheme: dark) {
   .error {
     /* #d4380d is below WCAG AA contrast on the dark card background. */
     color: #ff7a5c;
+  }
+
+  .success {
+    /* #237804 is below WCAG AA contrast on the dark card background. */
+    color: #95de64;
   }
 }
 

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,8 +1,10 @@
 import type { Metadata } from "next";
 
 import { FloatingMenu } from "@/app/components/FloatingMenu";
+import { safeNextPath } from "@/lib/safe-next";
 import { getCurrentUser } from "@/lib/session";
 
+import { ChangePasswordForm } from "./ChangePasswordForm";
 import styles from "./login.module.css";
 import { LoginForm } from "./LoginForm";
 import { LogoutForm } from "./LogoutForm";
@@ -19,6 +21,10 @@ type LoginPageProps = {
 export default async function LoginPage({ searchParams }: LoginPageProps) {
   const [user, { next }] = await Promise.all([getCurrentUser(), searchParams]);
 
+  // Sanitize once on the server so the change-password return link (rendered as
+  // an href) can never become an open redirect or a `javascript:` URL.
+  const returnTo = next !== undefined ? safeNextPath(next) : undefined;
+
   return (
     <>
       <div className={styles.main}>
@@ -34,6 +40,12 @@ export default async function LoginPage({ searchParams }: LoginPageProps) {
                 このログインは行事週間の各サイトで共通して使えます。
               </p>
               <LogoutForm next={next} />
+              <hr className={styles.divider} />
+              <h2 className={styles.subtitle}>パスワードの変更</h2>
+              <p className={styles.note}>
+                配布されたパスワードを、自分だけが知っているものに変更できます。各サイト共通のパスワードなので、変更すると他の端末・サイトからはログアウトされます。
+              </p>
+              <ChangePasswordForm next={returnTo} />
             </>
           ) : (
             <>

--- a/db/deleteUserSessions.ts
+++ b/db/deleteUserSessions.ts
@@ -8,6 +8,9 @@ import { db, type Executor } from "@/lib/db";
 // fresh session for the device that performed the change. Keyed by username, so
 // it needs no knowledge of any current token. Accepts an executor so it can run
 // in the same transaction as the password update.
-export async function deleteUserSessions(username: string, executor: Executor = db) {
+export async function deleteUserSessions(
+  username: string,
+  executor: Executor = db,
+) {
   await executor.delete(sessions).where(eq(sessions.username, username));
 }

--- a/db/deleteUserSessions.ts
+++ b/db/deleteUserSessions.ts
@@ -1,12 +1,13 @@
 import { eq } from "drizzle-orm";
 
 import { sessions } from "@/db/schema";
-import { db } from "@/lib/db";
+import { db, type Executor } from "@/lib/db";
 
 // Delete every session row for a user. Used after a password change so the new
 // password invalidates logins on all other devices; the caller then re-issues a
 // fresh session for the device that performed the change. Keyed by username, so
-// it needs no knowledge of any current token.
-export async function deleteUserSessions(username: string) {
-  await db.delete(sessions).where(eq(sessions.username, username));
+// it needs no knowledge of any current token. Accepts an executor so it can run
+// in the same transaction as the password update.
+export async function deleteUserSessions(username: string, executor: Executor = db) {
+  await executor.delete(sessions).where(eq(sessions.username, username));
 }

--- a/db/deleteUserSessions.ts
+++ b/db/deleteUserSessions.ts
@@ -1,0 +1,12 @@
+import { eq } from "drizzle-orm";
+
+import { sessions } from "@/db/schema";
+import { db } from "@/lib/db";
+
+// Delete every session row for a user. Used after a password change so the new
+// password invalidates logins on all other devices; the caller then re-issues a
+// fresh session for the device that performed the change. Keyed by username, so
+// it needs no knowledge of any current token.
+export async function deleteUserSessions(username: string) {
+  await db.delete(sessions).where(eq(sessions.username, username));
+}

--- a/db/updateUserPassword.ts
+++ b/db/updateUserPassword.ts
@@ -1,16 +1,18 @@
 import { eq } from "drizzle-orm";
 
 import { users } from "@/db/schema";
-import { db } from "@/lib/db";
+import { db, type Executor } from "@/lib/db";
 
 // Replace a user's bcrypt password hash. The change-password flow authorizes
 // the caller against the session and re-verifies the current password before
-// calling this — never trust a username from form input here.
+// calling this — never trust a username from form input here. Accepts an
+// executor so it can run inside the same transaction as the session purge.
 export async function updateUserPassword(
   username: string,
   passwordHash: string,
+  executor: Executor = db,
 ) {
-  await db
+  await executor
     .update(users)
     .set({ passwordHash })
     .where(eq(users.username, username));

--- a/db/updateUserPassword.ts
+++ b/db/updateUserPassword.ts
@@ -1,0 +1,17 @@
+import { eq } from "drizzle-orm";
+
+import { users } from "@/db/schema";
+import { db } from "@/lib/db";
+
+// Replace a user's bcrypt password hash. The change-password flow authorizes
+// the caller against the session and re-verifies the current password before
+// calling this — never trust a username from form input here.
+export async function updateUserPassword(
+  username: string,
+  passwordHash: string,
+) {
+  await db
+    .update(users)
+    .set({ passwordHash })
+    .where(eq(users.username, username));
+}

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -30,3 +30,8 @@ export const db = new Proxy({} as Db, {
     return typeof value === "function" ? value.bind(target) : value;
   },
 });
+
+// A Drizzle executor: either the shared `db` or a transaction handle yielded by
+// `db.transaction(...)`. Query helpers accept this (defaulting to `db`) so a
+// caller can compose several writes into one atomic transaction.
+export type Executor = Db | Parameters<Parameters<Db["transaction"]>[0]>[0];

--- a/lib/safe-next.ts
+++ b/lib/safe-next.ts
@@ -1,0 +1,51 @@
+import "server-only";
+
+/**
+ * Resolve a caller-supplied `next` to a URL we are willing to send a user to,
+ * or "/" when it isn't one. Shared by the /login server actions (which redirect
+ * to it) and the /login page's cross-app return link (which renders it as an
+ * href), so both apply the same allow-list. Reads SESSION_COOKIE_DOMAIN, a
+ * server-only env var, so this must run on the server.
+ */
+
+// A satellite app (equipment.2026.kss-it.com, …) sends the user to the shared
+// /login and wants them back afterwards, so we accept absolute https URLs whose
+// host is in the SESSION_COOKIE_DOMAIN family — and nothing else. The whole
+// `*.2026.kss-it.com` namespace is committee-controlled, so this isn't an open
+// redirect; an unrelated host still falls back to "/".
+function isAllowedReturnHost(host: string): boolean {
+  const domain = process.env.SESSION_COOKIE_DOMAIN;
+  if (!domain) return false;
+  return host === domain || host.endsWith(`.${domain}`);
+}
+
+export function safeNextPath(value: FormDataEntryValue | null): string {
+  if (typeof value !== "string") return "/";
+
+  // Same-site relative path. Resolve against a sentinel origin and require it
+  // to survive unchanged: a plain startsWith("/") check isn't enough because
+  // browsers fold "\" to "/", so "/\evil.com" (and control chars, "//evil.com")
+  // resolve to a foreign origin.
+  if (value.startsWith("/")) {
+    try {
+      const url = new URL(value, "https://placeholder.invalid");
+      if (url.origin !== "https://placeholder.invalid") return "/";
+      return url.pathname + url.search + url.hash;
+    } catch {
+      return "/";
+    }
+  }
+
+  // Absolute URL back to a sibling app under the 2026 namespace. A non-https
+  // scheme (e.g. javascript:) never matches, so this can't render a dangerous
+  // href.
+  try {
+    const url = new URL(value);
+    if (url.protocol === "https:" && isAllowedReturnHost(url.host)) {
+      return url.toString();
+    }
+  } catch {
+    // not a parseable absolute URL — fall through
+  }
+  return "/";
+}


### PR DESCRIPTION
This thing basically just increases security vulnerability, but many people wants it. That's tough.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a password-change section to the login page for already signed-in users.
  * Password updates require current password, new password, and confirmation (with a minimum of 8 characters).
  * After success, all other active sessions are invalidated and a fresh session is created for the current device.
  * Password change attempts are rate-limited and show clear success/error feedback.
  * “Return/next” navigation is safely validated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->