### PR TITLE
change request page's Japanese

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -312,7 +312,7 @@ export default function Toppage() {
           { label: "創作展", href: "#create" },
           { label: "後夜祭", href: "#ceremony" },
           { label: "News", href: "/news/list" },
-          { label: "機能・修正の\nリクエスト", href: "/requests" },
+          { label: "ページ改善の提案", href: "/requests" },
           { label: "Changelog", href: "/changelog" },
         ]}
       />

--- a/app/requests/page.tsx
+++ b/app/requests/page.tsx
@@ -43,10 +43,10 @@ export default function RequestPage() {
       <Internal>
         <h2 className={styles.sectionTitle}>委員に直接伝える</h2>
         <p className={styles.description}>
-          委員に直接伝えていただければ、委員会で話し合いのうえ、機能の追加や修正を実装します。
+          IT委員に直接お伝えください。内容を委員会で検討し、必要に応じて新機能の追加や修正を行います。
         </p>
       </Internal>
-      <h2 className={styles.sectionTitle}>GitHubにてIssueを作成する</h2>
+      <h2 className={styles.sectionTitle}>GitHub上でIssueを作成する</h2>
       <p className={styles.description}>
         <Link
           className={styles.link}
@@ -54,7 +54,7 @@ export default function RequestPage() {
         >
           このページのリポジトリ
         </Link>
-        にIssueを作成していただくと、話し合いの後、新機能や修正が実装されます。
+        にIssueを作成してください。内容を委員会で検討し、必要に応じて新機能の追加や修正を行います。
       </p>
       <h2 className={styles.sectionTitle}>委員会にメールを送る</h2>
       <p className={styles.description}>
@@ -62,7 +62,7 @@ export default function RequestPage() {
           className={styles.link}
           href={"mailto:koishikawa.itcommittee@gmail.com"}
         >
-          委員会のメールアドレス
+          委員会のメールアドレス(koishikawa.itcommittee@gmail.com)
         </Link>
         宛にメールをお送りください。その際、どのページに関する提案か（このページであれば「行事週間トップページ」）を本文に記載してください。
       </p>

--- a/app/requests/page.tsx
+++ b/app/requests/page.tsx
@@ -50,7 +50,9 @@ export default function RequestPage() {
       <p className={styles.description}>
         <Link
           className={styles.link}
-          href={"https://github.com/KSS-IT-Committee/2026-event-week-top"}
+          href={
+            "https://github.com/KSS-IT-Committee/2026-event-week-top/issues/new"
+          }
         >
           このページのリポジトリ
         </Link>

--- a/content/changelog/0195-changelog.json
+++ b/content/changelog/0195-changelog.json
@@ -1,5 +1,5 @@
 {
-  "title": "change request page's Japanese",
-  "description": "TODO",
-  "credits": ["@SakaYq4875"]
+  "title": "リクエストページの日本語とリンクを修正",
+  "description": "リクエストページの日本語の表現とGitHubリンクを修正しました。",
+  "credits": ["@SakaYq4875", "@rotarymars"]
 }

--- a/content/changelog/0195-changelog.json
+++ b/content/changelog/0195-changelog.json
@@ -1,0 +1,5 @@
+{
+  "title": "change request page's Japanese",
+  "description": "TODO",
+  "credits": ["@SakaYq4875"]
+}


### PR DESCRIPTION
詳しくは[こちら](https://github.com/KSS-IT-Committee/2026-sousakuten-info/pull/141)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Text Updates**
  * Updated the menu label for submitting requests to “ページ改善の提案”.
  * Refined the request page instructional text and section heading for: contacting the IT committee, creating GitHub issues, and sending emails.
  * Expanded the email link text to display the full committee email address for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->