### PR TITLE
adding forced-colors

### DIFF
--- a/app/components/FloatingMenu/floating.module.css
+++ b/app/components/FloatingMenu/floating.module.css
@@ -100,6 +100,52 @@
   }
 }
 
+/*
+ * Forced Colors Mode (Edge "Page colours" / Windows High Contrast).
+ * The browser drops box-shadow and rewrites background to the system Canvas
+ * color, so the menu and hamburger would blend into the page. Add explicit
+ * system-color borders/fills so their boundaries stay visible with guaranteed
+ * contrast.
+ */
+@media (forced-colors: active) {
+  .menu {
+    /* Force a solid system background so blurred page content can't bleed
+       through and drop contrast; add a border for a visible boundary. */
+    background: Canvas;
+    -webkit-backdrop-filter: none;
+    backdrop-filter: none;
+    border: 1px solid CanvasText;
+  }
+
+  .link {
+    /* Pin the link text to a system color; the author #333 would otherwise
+       stay dark and vanish on a dark forced-colors Canvas. */
+    color: LinkText;
+  }
+
+  .link:hover,
+  .link:focus-visible {
+    /* SelectedItem/SelectedItemText are an opaque, guaranteed-contrast system
+       pair. forced-color-adjust:none opts this state out of the Canvas text
+       backplate the browser paints behind glyphs, which would otherwise wash
+       the label out (e.g. white-on-white in a light high-contrast theme). */
+    background: SelectedItem;
+    color: SelectedItemText;
+    forced-color-adjust: none;
+  }
+
+  .hamburger {
+    background: ButtonFace;
+    -webkit-backdrop-filter: none;
+    backdrop-filter: none;
+    border: 1px solid ButtonText;
+  }
+
+  .hamburger span {
+    background: ButtonText;
+  }
+}
+
 @media (max-width: 640px) {
   .wrapper {
     right: 0.5rem;

--- a/content/changelog/0207-changelog.json
+++ b/content/changelog/0207-changelog.json
@@ -1,5 +1,5 @@
 {
-  "title": "adding forced-colors",
-  "description": "TODO",
-  "credits": ["@rotarymars"]
+  "title": "メニューの色設定の改善",
+  "description": "特定のブラウザ設定において、ハンバーガーメニューの色が正しく表示されない問題を解決しました。",
+  "credits": ["@Kawasemi", "@rotarymars"]
 }

--- a/content/changelog/0207-changelog.json
+++ b/content/changelog/0207-changelog.json
@@ -1,0 +1,5 @@
+{
+  "title": "adding forced-colors",
+  "description": "TODO",
+  "credits": ["@rotarymars"]
+}


### PR DESCRIPTION
closes #164 
This fixes the bug #164, and it allows to see menu buttons even with page colors on edge browser.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved menu visibility in Windows High Contrast / Forced Colors mode.
  * Updated hover, focus, and menu button styling to maintain readable contrast and avoid visual blending.

* **Documentation**
  * Added a new changelog entry describing the menu color improvement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->