### PR TITLE
change darkmord color

### DIFF
--- a/app/top-page.module.css
+++ b/app/top-page.module.css
@@ -409,7 +409,7 @@
     color: rgb(140, 184, 252);
   }
   .eventTop {
-    background-image: linear-gradient(90deg, #ffffff 50%, #1e2c66 100%);
+    background: rgb(255, 255, 255);
   }
   .eventNewsList * {
     color: rgb(255, 255, 255) !important;
@@ -465,6 +465,7 @@
     display: flex;
     flex-direction: column;
     align-items: left;
+    margin: 10px 10px 0;
   }
   .themeImage {
     width: 400px !important;

--- a/app/top-page.module.css
+++ b/app/top-page.module.css
@@ -465,7 +465,6 @@
     display: flex;
     flex-direction: column;
     align-items: left;
-    margin: 10px 10px 0;
   }
   .themeImage {
     width: 400px !important;

--- a/content/changelog/0208-changelog.json
+++ b/content/changelog/0208-changelog.json
@@ -1,0 +1,5 @@
+{
+  "title": "change darkmord color",
+  "description": "TODO",
+  "credits": ["@kinoto0103"]
+}

--- a/content/changelog/0208-changelog.json
+++ b/content/changelog/0208-changelog.json
@@ -1,5 +1,5 @@
 {
-  "title": "change darkmord color",
-  "description": "TODO",
+  "title": "change darkmode color",
+  "description": "ダークモードのグラデーションをなくし、行事のテーマを見やすくしました。",
   "credits": ["@kinoto0103"]
 }


### PR DESCRIPTION
ダークモードでのeventTopのグラデーションをなくしました（スマホで見るとテーマの文字が見にくくなっていたため）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dark-mode appearance for the event top section by switching from a gradient background to a solid white background for better readability.
* **Documentation**
  * Added a new changelog entry describing the dark-mode visual update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->