### PR TITLE
Create a news section from IT committee

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -26,6 +26,9 @@ const sousakutenNews = getNews()
 const koyasaiNews = getNews()
   .filter((data) => data.tag === "ceremony")
   .slice(0, 3);
+const ITcommitteeNews = getNews()
+  .filter((data) => data.tag === "itcommittee")
+  .slice(0, 3);
 
 export const metadata: Metadata = {
   title: "2026年度行事週間",
@@ -304,18 +307,33 @@ export default function Toppage() {
             )}
           </div>
         </div>
+        {/* IT委員会ニュース */}
+        <div id="itcommittee" className={styles.event}>
+          <div className={styles.content}>
+            <p>《IT委員会からのお知らせ》</p>
+            {ITcommitteeNews.length === 0 ? (
+              <p>お知らせはまだありません。</p>
+            ) : (
+              <ul className={styles.eventNewsList}>
+                {ITcommitteeNews.map((item) => (
+                  <NewsItem key={item.id} item={item} />
+                ))}
+              </ul>
+            )}
+          </div>
+        </div>
+        <FloatingMenu
+          items={[
+            { label: "芸能祭", href: "#performance" },
+            { label: "体育祭", href: "#sports" },
+            { label: "創作展", href: "#create" },
+            { label: "後夜祭", href: "#ceremony" },
+            { label: "News", href: "/news/list" },
+            { label: "ページ改善の提案", href: "/requests" },
+            { label: "Changelog", href: "/changelog" },
+          ]}
+        />
       </div>
-      <FloatingMenu
-        items={[
-          { label: "芸能祭", href: "#performance" },
-          { label: "体育祭", href: "#sports" },
-          { label: "創作展", href: "#create" },
-          { label: "後夜祭", href: "#ceremony" },
-          { label: "News", href: "/news/list" },
-          { label: "ページ改善の提案", href: "/requests" },
-          { label: "Changelog", href: "/changelog" },
-        ]}
-      />
     </>
   );
 }

--- a/content/changelog/0236-changelog.json
+++ b/content/changelog/0236-changelog.json
@@ -1,0 +1,5 @@
+{
+  "title": "Create a news section from IT committee",
+  "description": "TODO",
+  "credits": ["@Shirym-min"]
+}

--- a/content/changelog/0236-changelog.json
+++ b/content/changelog/0236-changelog.json
@@ -1,5 +1,5 @@
 {
-  "title": "Create a news section from IT committee",
-  "description": "TODO",
+  "title": "IT委員会からのニュースセクションを追加",
+  "description": "IT委員会からのお知らせを確認できるようになりました。",
   "credits": ["@Shirym-min"]
 }


### PR DESCRIPTION
closes #129 
IT委員会からのニュースセクションを一番下に追加しました。
```md
tag: "itcommittee"
```
で表示されます。