### PR TITLE
unifying the floating menu behavior across repositories

### DIFF
--- a/app/components/FloatingMenu/FloatingMenuShell.tsx
+++ b/app/components/FloatingMenu/FloatingMenuShell.tsx
@@ -1,56 +1,37 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import styles from "./floating.module.css";
 
-const DEFAULT_COLLAPSE_DELAY_MS = 2000;
-
 type FloatingMenuShellProps = {
   children: React.ReactNode;
-  collapseDelayMs?: number;
 };
 
 /**
- * The interactive chrome of <FloatingMenu>: collapse timer, hover/focus
- * handling and the hamburger. The links arrive as `children`, already rendered
- * on the server, because internal-only entries are gated by <Internal> — an
+ * The interactive chrome of <FloatingMenu>: open/close state, hover handling
+ * and the menu button. The links arrive as `children`, already rendered on
+ * the server, because internal-only entries are gated by <Internal> — an
  * async Server Component that cannot run in the browser.
  *
- * Since the links are rendered on the server, `isOpen` can no longer be stamped
- * onto each one as `tabIndex`. `inert` does that job from an ancestor instead:
- * it makes the whole collapsed subtree unfocusable, unclickable and hidden from
- * assistive tech, so it also stands in for `aria-hidden` on the same element.
+ * Click/tap is the one open path that must always work. Hover open/close is
+ * limited to `pointerType === "mouse"`: a tap's synthetic mouseenter would
+ * otherwise open the menu mid-tap, swap the button to pointer-events: none,
+ * and let the tail of the tap land on the nav underneath — the "menu needs
+ * two taps on mobile" bug. For the same reason there is no timer-based
+ * auto-collapse; a tap-opened menu stays open until an outside press, a link
+ * click, Escape, or focus leaving it.
+ *
+ * Since the links are rendered on the server, `isOpen` can no longer be
+ * stamped onto each one as `tabIndex`. `inert` does that job from an ancestor
+ * instead: it makes the whole collapsed subtree unfocusable, unclickable and
+ * hidden from assistive tech, so it also stands in for `aria-hidden` on the
+ * same element.
  */
-export function FloatingMenuShell({
-  children,
-  collapseDelayMs = DEFAULT_COLLAPSE_DELAY_MS,
-}: FloatingMenuShellProps) {
+export function FloatingMenuShell({ children }: FloatingMenuShellProps) {
   const [isOpen, setIsOpen] = useState(false);
-  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const wrapperRef = useRef<HTMLDivElement>(null);
-
-  const scheduleCollapse = useCallback(() => {
-    if (timerRef.current) clearTimeout(timerRef.current);
-    timerRef.current = setTimeout(() => setIsOpen(false), collapseDelayMs);
-  }, [collapseDelayMs]);
-
-  const cancelCollapse = useCallback(() => {
-    if (timerRef.current) {
-      clearTimeout(timerRef.current);
-      timerRef.current = null;
-    }
-  }, []);
-
-  const collapseNow = useCallback(() => {
-    cancelCollapse();
-    setIsOpen(false);
-  }, [cancelCollapse]);
-
-  useEffect(() => {
-    scheduleCollapse();
-    return () => cancelCollapse();
-  }, [scheduleCollapse, cancelCollapse]);
+  const buttonRef = useRef<HTMLButtonElement>(null);
 
   // Collapse when a pointer press lands outside the menu.
   useEffect(() => {
@@ -58,71 +39,76 @@ export function FloatingMenuShell({
 
     const handlePointerDown = (event: PointerEvent) => {
       if (!wrapperRef.current?.contains(event.target as Node)) {
-        collapseNow();
+        setIsOpen(false);
       }
     };
 
     document.addEventListener("pointerdown", handlePointerDown);
     return () => document.removeEventListener("pointerdown", handlePointerDown);
-  }, [isOpen, collapseNow]);
-
-  // On devices with a mouse, collapse when the pointer leaves the viewport.
-  useEffect(() => {
-    if (!isOpen) return;
-    if (!window.matchMedia("(hover: hover)").matches) return;
-
-    const handleMouseOut = (event: MouseEvent) => {
-      // relatedTarget is null when the pointer leaves the browser window.
-      if (event.relatedTarget === null) {
-        collapseNow();
-      }
-    };
-
-    document.addEventListener("mouseout", handleMouseOut);
-    return () => document.removeEventListener("mouseout", handleMouseOut);
-  }, [isOpen, collapseNow]);
-
-  const handleOpen = () => {
-    setIsOpen(true);
-    scheduleCollapse();
-  };
+  }, [isOpen]);
 
   return (
-    <div ref={wrapperRef} className={styles.wrapper}>
-      <nav
-        id="floating-menu-nav"
-        inert={!isOpen}
-        className={`${styles.menu} ${isOpen ? styles.visible : styles.hidden}`}
-        aria-label="ページ内ナビゲーション"
-        onMouseEnter={cancelCollapse}
-        onMouseLeave={collapseNow}
-        onFocus={cancelCollapse}
-        onBlur={(e) => {
-          if (!e.currentTarget.contains(e.relatedTarget as Node)) {
-            collapseNow();
-          }
-        }}
-      >
-        {children}
-      </nav>
-
+    <div
+      ref={wrapperRef}
+      className={styles.wrapper}
+      // Enter/leave on the wrapper covers the button and the nav as one
+      // hover region, so the menu can't get stuck open when the pointer
+      // skims the button without ever reaching the nav.
+      onPointerEnter={(event) => {
+        if (event.pointerType === "mouse") setIsOpen(true);
+      }}
+      onPointerLeave={(event) => {
+        if (event.pointerType === "mouse") setIsOpen(false);
+      }}
+      onKeyDown={(event) => {
+        if (event.key === "Escape" && isOpen) {
+          setIsOpen(false);
+          buttonRef.current?.focus();
+        }
+      }}
+    >
+      {/* Button first in DOM so that Tab after opening lands on the first
+          link; both siblings are absolutely positioned, so order does not
+          affect layout. */}
       <button
+        ref={buttonRef}
         aria-expanded={isOpen}
         aria-controls="floating-menu-nav"
         type="button"
         className={`${styles.hamburger} ${
           isOpen ? styles.hidden : styles.visible
         }`}
-        aria-label="メニューを開く"
         tabIndex={isOpen ? -1 : 0}
-        onClick={handleOpen}
-        onMouseEnter={handleOpen}
-        onFocus={handleOpen}
+        onClick={() => setIsOpen(true)}
       >
-        <span />
-        <span />
-        <span />
+        <span className={styles.bars} aria-hidden="true">
+          <span />
+          <span />
+          <span />
+        </span>
+        メニュー
       </button>
+
+      <nav
+        id="floating-menu-nav"
+        inert={!isOpen}
+        className={`${styles.menu} ${isOpen ? styles.visible : styles.hidden}`}
+        aria-label="サイト内ナビゲーション"
+        // The menu outlives page navigations (it is rendered from the
+        // layout), so following a link must close it explicitly.
+        onClick={(event) => {
+          if ((event.target as HTMLElement).closest("a")) {
+            setIsOpen(false);
+          }
+        }}
+        onBlur={(event) => {
+          if (!event.currentTarget.contains(event.relatedTarget as Node)) {
+            setIsOpen(false);
+          }
+        }}
+      >
+        {children}
+      </nav>
     </div>
   );
 }

--- a/app/components/FloatingMenu/floating.module.css
+++ b/app/components/FloatingMenu/floating.module.css
@@ -28,6 +28,18 @@
   pointer-events: none;
 }
 
+/* Translucent so page content near the bottom edge stays readable behind
+   the menu; the backdrop blur keeps the labels legible over it. */
+.menu,
+.hamburger {
+  background: rgba(255, 255, 255, 0.82);
+  -webkit-backdrop-filter: blur(8px);
+  backdrop-filter: blur(8px);
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
+  transform-origin: bottom right;
+}
+
 .menu {
   display: flex;
   flex-direction: column;
@@ -37,14 +49,12 @@
   max-width: min(320px, calc(100vw - 2rem));
   max-height: min(70vh, 480px);
   overflow-y: auto;
-  background: #fff;
-  -webkit-backdrop-filter: blur(8px);
-  backdrop-filter: blur(8px);
   border-radius: 12px;
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
-  transform-origin: bottom right;
 }
 
+/* Colors are self-contained (hardcoded light/dark) so this file can be
+   copied byte-identical across the app repos regardless of each app's
+   CSS variable vocabulary — same convention as AccountNav.module.css. */
 .link {
   color: #333;
   text-decoration: none;
@@ -63,34 +73,59 @@
 
 .hamburger {
   display: flex;
-  flex-direction: column;
-  justify-content: center;
   align-items: center;
-  gap: 5px;
-  width: 44px;
-  height: 44px;
-  padding: 0;
-  background: #fff;
-  -webkit-backdrop-filter: blur(8px);
-  backdrop-filter: blur(8px);
-  border: none;
-  border-radius: 12px;
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
+  gap: 0.5rem;
+  /* The wrapper is a zero-size anchor, so an absolutely-positioned button
+     would otherwise shrink to zero width and wrap the label vertically. */
+  width: max-content;
+  min-height: 48px;
+  padding: 0.6rem 1.1rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #333;
+  border-radius: 9999px;
   cursor: pointer;
-  transform-origin: bottom right;
 }
 
 .hamburger:hover {
-  background: rgba(255, 255, 255, 1);
+  background: rgba(255, 255, 255, 0.95);
   box-shadow: 0 6px 24px rgba(0, 0, 0, 0.15);
 }
 
-.hamburger span {
+.bars {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 4px;
+}
+
+.bars span {
   display: block;
-  width: 22px;
+  width: 18px;
   height: 2px;
-  background: #333;
+  background: currentColor;
   border-radius: 2px;
+}
+
+@media (prefers-color-scheme: dark) {
+  .menu,
+  .hamburger {
+    background: rgba(17, 17, 17, 0.8);
+    border-color: rgba(255, 255, 255, 0.12);
+  }
+
+  .link,
+  .hamburger {
+    color: #ddd;
+  }
+
+  .link:hover {
+    background: rgba(255, 255, 255, 0.1);
+  }
+
+  .hamburger:hover {
+    background: rgba(34, 34, 34, 0.95);
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -103,9 +138,10 @@
 /*
  * Forced Colors Mode (Edge "Page colours" / Windows High Contrast).
  * The browser drops box-shadow and rewrites background to the system Canvas
- * color, so the menu and hamburger would blend into the page. Add explicit
+ * color, so the menu and button would blend into the page. Add explicit
  * system-color borders/fills so their boundaries stay visible with guaranteed
- * contrast.
+ * contrast. The bars use currentColor and follow the forced text color on
+ * their own.
  */
 @media (forced-colors: active) {
   .menu {
@@ -118,8 +154,8 @@
   }
 
   .link {
-    /* Pin the link text to a system color; the author #333 would otherwise
-       stay dark and vanish on a dark forced-colors Canvas. */
+    /* Pin the link text to a system color; the author foreground would
+       otherwise stay dark and vanish on a dark forced-colors Canvas. */
     color: LinkText;
   }
 
@@ -135,14 +171,11 @@
   }
 
   .hamburger {
+    color: ButtonText;
     background: ButtonFace;
     -webkit-backdrop-filter: none;
     backdrop-filter: none;
     border: 1px solid ButtonText;
-  }
-
-  .hamburger span {
-    background: ButtonText;
   }
 }
 

--- a/app/components/FloatingMenu/floating.module.css
+++ b/app/components/FloatingMenu/floating.module.css
@@ -103,7 +103,7 @@
   display: block;
   width: 18px;
   height: 2px;
-  background: currentColor;
+  background: currentcolor;
   border-radius: 2px;
 }
 

--- a/app/components/FloatingMenu/index.tsx
+++ b/app/components/FloatingMenu/index.tsx
@@ -21,7 +21,6 @@ export type FloatingMenuItem = {
 
 type FloatingMenuProps = {
   items: FloatingMenuItem[];
-  collapseDelayMs?: number;
 };
 
 function FloatingMenuLink({ item }: { item: FloatingMenuItem }) {
@@ -42,9 +41,9 @@ function FloatingMenuLink({ item }: { item: FloatingMenuItem }) {
  * Every call site therefore wants at least one ungated entry, or a logged-out
  * visitor opens an empty menu.
  */
-export function FloatingMenu({ items, collapseDelayMs }: FloatingMenuProps) {
+export function FloatingMenu({ items }: FloatingMenuProps) {
   return (
-    <FloatingMenuShell collapseDelayMs={collapseDelayMs}>
+    <FloatingMenuShell>
       {items.map((item) =>
         item.isInternal ? (
           <Internal key={item.href} role={item.role}>

--- a/content/changelog/0238-changelog.json
+++ b/content/changelog/0238-changelog.json
@@ -1,5 +1,5 @@
 {
-  "title": "unifying the floating menu behavior across repositories",
-  "description": "TODO",
+  "title": "フローティングメニューの動作を統一しました。",
+  "description": "フローティングメニューの動作を統一しました。",
   "credits": ["@rotarymars"]
 }

--- a/content/changelog/0238-changelog.json
+++ b/content/changelog/0238-changelog.json
@@ -1,0 +1,5 @@
+{
+  "title": "unifying the floating menu behavior across repositories",
+  "description": "TODO",
+  "credits": ["@rotarymars"]
+}


### PR DESCRIPTION
Copies the reworked FloatingMenu from 2026-sousakuten-info (PR #147 review feedback): single tap opens on mobile (hover open/close gated to mouse pointers, no timer-based auto-collapse), larger labelled button, semi-transparent surfaces with self-contained light/dark colors, Escape/Tab keyboard support.