### PR TITLE
adding more details about sousaku-bumon's parents

### DIFF
--- a/app/lottery/[lotteryId]/page.tsx
+++ b/app/lottery/[lotteryId]/page.tsx
@@ -134,6 +134,15 @@ async function LotteryDetail({
           {APPLICANT_TYPE_LABELS[applicantType]}としての申込（アカウント:{" "}
           {user.username}）
         </p>
+        {applicantType === "parent" &&
+          canApply &&
+          lottery.parentNotes !== undefined && (
+            <ul className={`${styles.notesList} ${styles.importantNotes}`}>
+              {lottery.parentNotes.map((note) => (
+                <li key={note}>{note}</li>
+              ))}
+            </ul>
+          )}
         {availability === "upcoming" && (
           <p className={styles.closed}>申込受付はまだ始まっていません。</p>
         )}

--- a/app/lottery/lottery.module.css
+++ b/app/lottery/lottery.module.css
@@ -38,6 +38,12 @@
   margin-bottom: 24px;
 }
 
+/* Layered on .notesList for notices the reader must not miss (e.g. how a
+   child's own class is prioritized) — declared after it so the red wins. */
+.importantNotes {
+  color: #d4380d;
+}
+
 .lotteryList {
   display: flex;
   flex-direction: column;
@@ -272,6 +278,11 @@
   }
 
   .ineligible {
+    color: #ff7a5c;
+  }
+
+  .importantNotes {
+    /* #d4380d is below WCAG AA contrast on the dark card background. */
     color: #ff7a5c;
   }
 

--- a/content/changelog/0247-changelog.json
+++ b/content/changelog/0247-changelog.json
@@ -1,5 +1,5 @@
 {
-  "title": "adding more details about sousaku-bumon's parents",
-  "description": "TODO",
+  "title": "抽選ページの説明の追加",
+  "description": "抽選ページの説明を追加しました。",
   "credits": ["@rotarymars"]
 }

--- a/content/changelog/0247-changelog.json
+++ b/content/changelog/0247-changelog.json
@@ -1,0 +1,5 @@
+{
+  "title": "adding more details about sousaku-bumon's parents",
+  "description": "TODO",
+  "credits": ["@rotarymars"]
+}

--- a/docs/LOTTERY.md
+++ b/docs/LOTTERY.md
@@ -58,6 +58,8 @@ moving parts and, most importantly, **how to add another lottery later**.
 1. Append a definition to `LOTTERIES` in `lib/lotteries.ts` — id, title,
    description, notes, `applicantTypes`, `eligibleClasses`, `canStaffApply`,
    `acts`, `slots`, window. **No schema change and no migration is needed.**
+   Optional `parentNotes` renders as red bullets on the 保護者 tab only
+   (sousaku uses it to explain the child's-class priority).
 2. Pick ids that will stay stable (`lottery_id`, slot ids, act ids are what
    gets stored; renaming them orphans saved entries).
 3. Extend `lib/lotteries.test.ts` with the new definition's pins (slot/act

--- a/docs/LOTTERY.md
+++ b/docs/LOTTERY.md
@@ -58,8 +58,9 @@ moving parts and, most importantly, **how to add another lottery later**.
 1. Append a definition to `LOTTERIES` in `lib/lotteries.ts` — id, title,
    description, notes, `applicantTypes`, `eligibleClasses`, `canStaffApply`,
    `acts`, `slots`, window. **No schema change and no migration is needed.**
-   Optional `parentNotes` renders as red bullets on the 保護者 tab only
-   (sousaku uses it to explain the child's-class priority).
+   Optional `parentNotes` renders as red bullets on the 保護者 tab only —
+   notices a parent must not miss (kaitaku: who may apply; sousaku: the
+   child's-class priority and its scope).
 2. Pick ids that will stay stable (`lottery_id`, slot ids, act ids are what
    gets stored; renaming them orphans saved entries).
 3. Extend `lib/lotteries.test.ts` with the new definition's pins (slot/act

--- a/lib/lotteries.test.ts
+++ b/lib/lotteries.test.ts
@@ -154,6 +154,15 @@ describe("LOTTERIES registry", () => {
     expect(sousaku.canStaffApply).toBe(true);
     expect(sousaku.eligibleClasses).toEqual([...CLASSNAMES]);
   });
+
+  it("explains the child's-class priority to sousaku parents only", () => {
+    const joined = (sousaku.parentNotes ?? []).join("");
+    expect(joined).toContain("第1希望");
+    expect(joined).toContain("創作部門");
+    // Kaitaku parents always watch their own child's class — nothing to
+    // explain there.
+    expect(kaitaku.parentNotes).toBeUndefined();
+  });
 });
 
 describe("getLottery", () => {

--- a/lib/lotteries.test.ts
+++ b/lib/lotteries.test.ts
@@ -155,13 +155,14 @@ describe("LOTTERIES registry", () => {
     expect(sousaku.eligibleClasses).toEqual([...CLASSNAMES]);
   });
 
-  it("explains the child's-class priority to sousaku parents only", () => {
-    const joined = (sousaku.parentNotes ?? []).join("");
-    expect(joined).toContain("第1希望");
-    expect(joined).toContain("創作部門");
-    // Kaitaku parents always watch their own child's class — nothing to
-    // explain there.
-    expect(kaitaku.parentNotes).toBeUndefined();
+  it("carries the important parent-facing notes for both lotteries", () => {
+    // Sousaku explains the child's-class priority and its scope.
+    const sousakuNotes = (sousaku.parentNotes ?? []).join("");
+    expect(sousakuNotes).toContain("第1希望");
+    expect(sousakuNotes).toContain("創作部門");
+    // Kaitaku states that only its own division's parents may apply.
+    const kaitakuNotes = (kaitaku.parentNotes ?? []).join("");
+    expect(kaitakuNotes).toContain("開拓部門");
   });
 });
 

--- a/lib/lotteries.ts
+++ b/lib/lotteries.ts
@@ -43,9 +43,9 @@ export type Lottery = {
   description: string;
   // Shown as bullet points on the application page (venue rules, breaks…).
   notes: readonly string[];
-  // Extra bullet points shown only on the 保護者 tab (e.g. how a child's
-  // own class is prioritized). Kaitaku deliberately has none: its parents
-  // always watch their own child's class, so only the time is asked.
+  // Extra bullet points shown in red on the 保護者 tab only — notices a
+  // parent must not miss (who may apply, how a child's own class is
+  // prioritized).
   parentNotes?: readonly string[];
   // Which kinds of applicant may enter, in display order. Parents apply via
   // their child's student account, so "parent" still authenticates as the
@@ -137,6 +137,9 @@ export const LOTTERIES: readonly Lottery[] = [
       "お昼休憩は60分です。第四公演のお客さんがはけ次第、12:15まで観客入場禁止となります。",
       "保護者の方はお子様のアカウントでログインして申し込んでください。保護者の方の希望はお子様のアカウント1つにつき1件です。",
       "観覧人数は1日につき2名まで選べます。",
+    ],
+    parentNotes: [
+      "この抽選に申し込めるのは、お子様が開拓部門（3・4年生）に在籍している保護者の方のみです。",
     ],
     applicantTypes: ["parent"],
     eligibleClasses: KAITAKU_CLASSES,

--- a/lib/lotteries.ts
+++ b/lib/lotteries.ts
@@ -43,6 +43,10 @@ export type Lottery = {
   description: string;
   // Shown as bullet points on the application page (venue rules, breaks…).
   notes: readonly string[];
+  // Extra bullet points shown only on the 保護者 tab (e.g. how a child's
+  // own class is prioritized). Kaitaku deliberately has none: its parents
+  // always watch their own child's class, so only the time is asked.
+  parentNotes?: readonly string[];
   // Which kinds of applicant may enter, in display order. Parents apply via
   // their child's student account, so "parent" still authenticates as the
   // child; one account holds at most one entry set per type.
@@ -157,6 +161,11 @@ export const LOTTERIES: readonly Lottery[] = [
       "生徒本人と保護者の方は、同じアカウントからそれぞれ別に申し込めます。保護者の方の希望はお子様のアカウント1つにつき1件です。",
       "教職員の方はご自身のアカウントでログインして申し込んでください。",
       "保護者の方の観覧人数は1公演につき2名まで選べます（生徒本人・教職員の方は1名です）。",
+    ],
+    parentNotes: [
+      "お子様のクラスを第1希望に選んだ公演は、その公演の申込人数が座席数を超えない限り、そのまま観覧できます。お子様の公演を観覧するには、いずれか1公演で第1希望に選ぶだけで大丈夫です。",
+      "お子様のクラスを2公演以上で希望した場合、優先して観覧できるのはいずれか1公演のみです。それ以外の希望は、他の申込者の方と同じ条件で抽選されます。",
+      "これらの優先は、お子様が創作部門（5・6年生）に在籍している保護者の方にのみ適用されます。",
     ],
     applicantTypes: ["student", "parent"],
     eligibleClasses: [...CLASSNAMES],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added parent-specific important notes to eligible lottery detail pages.
  * Notes appear as clearly highlighted bullet points on the 保護者 tab.
  * Added guidance for the sousaku lottery describing first-choice viewing priorities.

* **Documentation**
  * Documented the optional `parentNotes` lottery configuration.

* **Tests**
  * Added coverage verifying parent notes for sousaku and their absence for kaitaku.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->