### PR TITLE
Decide lottery eligibility from session roles, not username shape

### DIFF
--- a/app/lottery/[lotteryId]/actions.ts
+++ b/app/lottery/[lotteryId]/actions.ts
@@ -77,9 +77,9 @@ export async function submitLotteryEntriesAction(
   const applicantType = applicantTypeValue;
 
   // Eligibility is re-checked here (not only in the page) because the action
-  // is directly invocable: the account's class must belong to the lottery and
-  // the applicant type must be offered by it.
-  if (!canApplyToLottery(lottery, user.username, applicantType)) {
+  // is directly invocable: the account's role-derived class must belong to
+  // the lottery and the applicant type must be offered by it.
+  if (!canApplyToLottery(lottery, user.roles, applicantType)) {
     return {
       error: "このアカウントではこの抽選に申し込めません。",
       success: false,

--- a/app/lottery/[lotteryId]/page.tsx
+++ b/app/lottery/[lotteryId]/page.tsx
@@ -73,7 +73,7 @@ async function LotteryDetail({
   // For a fully ineligible viewer nothing matches — fall back to the
   // lottery's own list so the page still renders the 対象外 explanation.
   const usableTypes = lottery.applicantTypes.filter((type) =>
-    canApplyToLottery(lottery, user.username, type),
+    canApplyToLottery(lottery, user.roles, type),
   );
   const offeredTypes =
     usableTypes.length > 0 ? usableTypes : lottery.applicantTypes;
@@ -87,7 +87,7 @@ async function LotteryDetail({
       ? requestedType
       : offeredTypes[0];
 
-  const canApply = canApplyToLottery(lottery, user.username, applicantType);
+  const canApply = canApplyToLottery(lottery, user.roles, applicantType);
   const availability = getLotteryAvailability(lottery, new Date());
   const deadline = describeApplicationDeadline(lottery);
   const maxPartySize = MAX_PARTY_SIZE_BY_APPLICANT_TYPE[applicantType];

--- a/app/lottery/page.tsx
+++ b/app/lottery/page.tsx
@@ -48,7 +48,7 @@ async function LotteryIndex() {
         <div className={styles.lotteryList}>
           {LOTTERIES.map((lottery) => {
             const availability = getLotteryAvailability(lottery, now);
-            const isEligible = isEligibleForLottery(lottery, user.username);
+            const isEligible = isEligibleForLottery(lottery, user.roles);
             const deadline = describeApplicationDeadline(lottery);
             return (
               <article key={lottery.id} className={styles.lotteryCard}>

--- a/content/changelog/0253-changelog.json
+++ b/content/changelog/0253-changelog.json
@@ -1,0 +1,5 @@
+{
+  "title": "Decide lottery eligibility from session roles, not username shape",
+  "description": "TODO",
+  "credits": ["@rotarymars"]
+}

--- a/content/changelog/0253-changelog.json
+++ b/content/changelog/0253-changelog.json
@@ -1,5 +1,5 @@
 {
-  "title": "Decide lottery eligibility from session roles, not username shape",
-  "description": "TODO",
+  "title": "抽選システムの修正",
+  "description": "抽選システムの内部の挙動を一部修正しました。",
   "credits": ["@rotarymars"]
 }

--- a/lib/lotteries.test.ts
+++ b/lib/lotteries.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import { CLASSNAMES } from "@/db/schema";
 import {
   canApplyToLottery,
+  classFromRoles,
   describeApplicationDeadline,
   describeEligibleGrades,
   getLottery,
@@ -14,6 +15,14 @@ import {
   MAX_PARTY_SIZE_BY_APPLICANT_TYPE,
   parseLotteryEntries,
 } from "@/lib/lotteries";
+
+// Role sets as 2026-account-generator's users.sql grants them: students get
+// grade + class + Students, staff get Teachers. Committee roles ride along
+// on some accounts and must not affect eligibility.
+function studentRoles(classCode: string): string[] {
+  return [`G${classCode[0]}`, `Class${classCode[1]}`, "Students"];
+}
+const TEACHER_ROLES = ["Teachers"];
 
 function mustGetLottery(lotteryId: string): Lottery {
   const lottery = getLottery(lotteryId);
@@ -166,57 +175,94 @@ describe("getLottery", () => {
   });
 });
 
-describe("isEligibleForLottery", () => {
-  it("accepts a kaitaku-class account for the kaitaku lottery", () => {
-    expect(isEligibleForLottery(kaitaku, "3A05")).toBe(true);
-    expect(isEligibleForLottery(kaitaku, "4D11")).toBe(true);
+describe("classFromRoles", () => {
+  it("derives the class from one grade role plus one class role", () => {
+    expect(classFromRoles(["G4", "ClassD", "Students"])).toBe("4D");
+    expect(classFromRoles(["G1", "ClassA", "Students"])).toBe("1A");
   });
 
-  it("rejects alias accounts (suffixed usernames) so one student cannot double-enter", () => {
-    expect(isEligibleForLottery(kaitaku, "4D11_sakuten")).toBe(false);
-    expect(isEligibleForLottery(sousaku, "1A01_test")).toBe(false);
+  it("ignores committee and other unrelated roles", () => {
+    expect(classFromRoles(["Sousakuten", "G4", "ClassD", "Students"])).toBe(
+      "4D",
+    );
+  });
+
+  it("returns null without exactly one grade and one class role", () => {
+    expect(classFromRoles([])).toBeNull();
+    expect(classFromRoles(["Students"])).toBeNull();
+    expect(classFromRoles(["G4", "Students"])).toBeNull();
+    expect(classFromRoles(["ClassD", "Students"])).toBeNull();
+    expect(classFromRoles(["G3", "G4", "ClassD", "Students"])).toBeNull();
+    expect(classFromRoles(["G4", "ClassC", "ClassD", "Students"])).toBeNull();
+  });
+});
+
+describe("isEligibleForLottery", () => {
+  it("accepts a kaitaku-class account for the kaitaku lottery", () => {
+    expect(isEligibleForLottery(kaitaku, studentRoles("3A"))).toBe(true);
+    expect(isEligibleForLottery(kaitaku, studentRoles("4D"))).toBe(true);
+  });
+
+  it("judges by roles alone, so an alias granted its base account's roles passes", () => {
+    // e.g. "4D11_sakuten" carrying the same roles as "4D11" — such aliases
+    // can hold a second entry set; only grant them roles where acceptable.
+    expect(
+      isEligibleForLottery(kaitaku, ["Sousakuten", "G4", "ClassD", "Students"]),
+    ).toBe(true);
   });
 
   it("rejects accounts of other divisions for the kaitaku lottery", () => {
-    expect(isEligibleForLottery(kaitaku, "2A01")).toBe(false);
-    expect(isEligibleForLottery(kaitaku, "5A01")).toBe(false);
+    expect(isEligibleForLottery(kaitaku, studentRoles("2A"))).toBe(false);
+    expect(isEligibleForLottery(kaitaku, studentRoles("5A"))).toBe(false);
   });
 
-  it("accepts staff accounts only where canStaffApply is set", () => {
-    expect(isEligibleForLottery(sousaku, "k0959176")).toBe(true);
-    expect(isEligibleForLottery(kaitaku, "k0959176")).toBe(false);
+  it("accepts Teachers accounts only where canStaffApply is set", () => {
+    expect(isEligibleForLottery(sousaku, TEACHER_ROLES)).toBe(true);
+    expect(isEligibleForLottery(kaitaku, TEACHER_ROLES)).toBe(false);
   });
 
-  it("rejects malformed staff usernames even on a staff lottery", () => {
-    expect(isEligibleForLottery(sousaku, "k0959176_x")).toBe(false);
-    expect(isEligibleForLottery(sousaku, "k095917")).toBe(false);
+  it("rejects role-less and committee-only accounts", () => {
+    expect(isEligibleForLottery(sousaku, [])).toBe(false);
+    expect(isEligibleForLottery(sousaku, ["IT"])).toBe(false);
+    expect(isEligibleForLottery(sousaku, ["Sousakuten"])).toBe(false);
+  });
+
+  it("rejects a Students account whose roles pin no single class", () => {
+    expect(isEligibleForLottery(sousaku, ["Students"])).toBe(false);
+    expect(isEligibleForLottery(sousaku, ["G4", "Students"])).toBe(false);
   });
 
   it("accepts every grade's students for the sousaku lottery", () => {
-    expect(isEligibleForLottery(sousaku, "1A01")).toBe(true);
-    expect(isEligibleForLottery(sousaku, "6D01")).toBe(true);
+    expect(isEligibleForLottery(sousaku, studentRoles("1A"))).toBe(true);
+    expect(isEligibleForLottery(sousaku, studentRoles("6D"))).toBe(true);
   });
 });
 
 describe("canApplyToLottery", () => {
   it("rejects an applicant type the lottery does not offer", () => {
-    expect(canApplyToLottery(kaitaku, "3A05", "student")).toBe(false);
+    expect(canApplyToLottery(kaitaku, studentRoles("3A"), "student")).toBe(
+      false,
+    );
   });
 
   it("accepts an offered applicant type for an eligible account", () => {
-    expect(canApplyToLottery(kaitaku, "3A05", "parent")).toBe(true);
-    expect(canApplyToLottery(sousaku, "1A01", "student")).toBe(true);
-    expect(canApplyToLottery(sousaku, "1A01", "parent")).toBe(true);
+    expect(canApplyToLottery(kaitaku, studentRoles("3A"), "parent")).toBe(true);
+    expect(canApplyToLottery(sousaku, studentRoles("1A"), "student")).toBe(
+      true,
+    );
+    expect(canApplyToLottery(sousaku, studentRoles("1A"), "parent")).toBe(true);
   });
 
   it("lets staff apply only as themselves, never as a parent", () => {
-    expect(canApplyToLottery(sousaku, "k0959176", "student")).toBe(true);
-    expect(canApplyToLottery(sousaku, "k0959176", "parent")).toBe(false);
-    expect(canApplyToLottery(kaitaku, "k0959176", "parent")).toBe(false);
+    expect(canApplyToLottery(sousaku, TEACHER_ROLES, "student")).toBe(true);
+    expect(canApplyToLottery(sousaku, TEACHER_ROLES, "parent")).toBe(false);
+    expect(canApplyToLottery(kaitaku, TEACHER_ROLES, "parent")).toBe(false);
   });
 
   it("rejects an ineligible account even for an offered type", () => {
-    expect(canApplyToLottery(kaitaku, "5A01", "parent")).toBe(false);
+    expect(canApplyToLottery(kaitaku, studentRoles("5A"), "parent")).toBe(
+      false,
+    );
   });
 });
 

--- a/lib/lotteries.ts
+++ b/lib/lotteries.ts
@@ -4,7 +4,6 @@ import {
   isClassName,
   type LotteryApplicantType,
 } from "@/db/schema";
-import { classOf } from "@/lib/user-category";
 
 /**
  * Viewing-lottery definitions and the pure rules around them.
@@ -47,12 +46,12 @@ export type Lottery = {
   // their child's student account, so "parent" still authenticates as the
   // child; one account holds at most one entry set per type.
   applicantTypes: readonly LotteryApplicantType[];
-  // The account's class (classOf(username)) must be one of these. For
-  // parents this is the child's class — "parents with a child in the
+  // The account's class (classFromRoles(user.roles)) must be one of these.
+  // For parents this is the child's class — "parents with a child in the
   // division" is exactly "accounts of that division's classes".
   eligibleClasses: readonly ClassName[];
-  // Whether staff (k-prefixed) accounts may enter. Staff have no class, so
-  // eligibleClasses never admits them; they apply as themselves via the
+  // Whether staff (Teachers-role) accounts may enter. Staff have no class,
+  // so eligibleClasses never admits them; they apply as themselves via the
   // "student" applicant type (labeled 本人), never as "parent".
   canStaffApply: boolean;
   // What an applicant ranks (up to MAX_CHOICES_PER_SLOT) within each slot.
@@ -71,18 +70,40 @@ export type Lottery = {
   closesAt: Date | null;
 };
 
-// Exactly one base student account per student (e.g. "3A05"). Deliberately
-// stricter than lib/user-category.ts's prefix-matching STUDENT_RE: alias
-// accounts like "4D11_sakuten" must not hold a second entry set on top of
-// the base account's, so lottery eligibility requires the exact form.
-const BASE_STUDENT_RE = /^[1-6][A-D]\d{2}$/;
+// Population roles → class code parts. Must stay in lockstep with the
+// G1–G6 / ClassA–ClassD members of ROLENAMES (db/schema.ts), which
+// 2026-account-generator derives from the roster. Plain string keys (not
+// the Role type): roles come off SessionUser.roles, which is string[] so
+// preview sessions stay forward-compatible with roles this build predates.
+const GRADE_BY_ROLE: Record<string, string> = {
+  G1: "1",
+  G2: "2",
+  G3: "3",
+  G4: "4",
+  G5: "5",
+  G6: "6",
+};
+const CLASS_LETTER_BY_ROLE: Record<string, string> = {
+  ClassA: "A",
+  ClassB: "B",
+  ClassC: "C",
+  ClassD: "D",
+};
 
-// Staff accounts: exactly k + 7 digits. Must stay in lockstep with the
-// staff shape 2026-account-generator/generate_sql.py derives the Teachers
-// role from (lib/user-category.ts no longer carries a staff regex — guards
-// are role-based). Anchored for the same one-account-one-entry-set reason
-// as BASE_STUDENT_RE.
-const STAFF_RE = /^k\d{7}$/;
+/**
+ * The class code an account's roles pin it to ("G4" + "ClassD" -> "4D"), or
+ * null when the roles don't name exactly one class — no grade/class roles
+ * (staff, committee-only accounts) or contradictory ones (two grades). Both
+ * roles come from 2026-account-generator's users.sql, so roster accounts —
+ * and hand-made aliases granted the same roles — resolve cleanly.
+ */
+export function classFromRoles(roles: readonly string[]): ClassName | null {
+  const grades = roles.filter((role) => role in GRADE_BY_ROLE);
+  const letters = roles.filter((role) => role in CLASS_LETTER_BY_ROLE);
+  if (grades.length !== 1 || letters.length !== 1) return null;
+  const classCode = GRADE_BY_ROLE[grades[0]] + CLASS_LETTER_BY_ROLE[letters[0]];
+  return isClassName(classCode) ? classCode : null;
+}
 
 function classesInGrades(grades: readonly string[]): ClassName[] {
   return CLASSNAMES.filter((className) => grades.includes(className[0]));
@@ -227,33 +248,37 @@ export function describeEligibleGrades(lottery: Lottery): string {
 }
 
 /**
- * Whether the account may take part in the lottery at all: either a staff
- * account on a lottery that admits staff, or a base student account
- * (aliases like "4D11_sakuten" are excluded so one student never yields two
- * entry sets) whose class (the child's class, for parents) is one of the
- * eligible classes. Committee and other non-matching accounts never pass.
+ * Whether the account may take part in the lottery at all, decided from the
+ * session's roles (never the username shape): either a Teachers account on
+ * a lottery that admits staff, or a Students account whose role-derived
+ * class (the child's class, for parents) is one of the eligible classes.
+ * Committee-only and other role-less accounts never pass. NOTE: an alias
+ * account granted the same roles as its base account (e.g. "4D11_sakuten"
+ * next to "4D11") is eligible too, and entries are keyed by username — so
+ * such aliases can hold a second entry set. Grant alias accounts student
+ * roles only where that is acceptable.
  */
 export function isEligibleForLottery(
   lottery: Lottery,
-  username: string,
+  roles: readonly string[],
 ): boolean {
-  if (STAFF_RE.test(username)) return lottery.canStaffApply;
-  if (!BASE_STUDENT_RE.test(username)) return false;
-  const classCode = classOf(username);
-  if (classCode === null || !isClassName(classCode)) return false;
+  if (roles.includes("Teachers")) return lottery.canStaffApply;
+  if (!roles.includes("Students")) return false;
+  const classCode = classFromRoles(roles);
+  if (classCode === null) return false;
   return lottery.eligibleClasses.includes(classCode);
 }
 
 export function canApplyToLottery(
   lottery: Lottery,
-  username: string,
+  roles: readonly string[],
   applicantType: LotteryApplicantType,
 ): boolean {
   if (!lottery.applicantTypes.includes(applicantType)) return false;
-  // Staff apply as themselves only — there is no child behind a k-account
-  // for a "parent" entry to belong to.
-  if (applicantType === "parent" && STAFF_RE.test(username)) return false;
-  return isEligibleForLottery(lottery, username);
+  // Staff apply as themselves only — there is no child behind a staff
+  // account for a "parent" entry to belong to.
+  if (applicantType === "parent" && roles.includes("Teachers")) return false;
+  return isEligibleForLottery(lottery, roles);
 }
 
 export type LotteryAvailability = "upcoming" | "open" | "closed";

--- a/test/app/lottery-actions.test.ts
+++ b/test/app/lottery-actions.test.ts
@@ -47,8 +47,21 @@ const fd = (o: Record<string, string>) => {
   return f;
 };
 
-function asUser(username: string) {
-  vi.mocked(getCurrentUser).mockResolvedValue({ username, roles: [] });
+// Session fixture. Eligibility is role-based, so grant the roles
+// 2026-account-generator's users.sql would: grade + class + Students for a
+// student username, Teachers for a k-account. Pass roles explicitly to
+// model accounts whose roles differ from their name's shape (aliases,
+// role-less committee accounts).
+function asUser(username: string, roles?: readonly string[]) {
+  const grantedRoles =
+    roles ??
+    (username.startsWith("k")
+      ? ["Teachers"]
+      : [`G${username[0]}`, `Class${username[1]}`, "Students"]);
+  vi.mocked(getCurrentUser).mockResolvedValue({
+    username,
+    roles: [...grantedRoles],
+  });
 }
 
 function mustGetLottery(lotteryId: string): Lottery {
@@ -226,8 +239,33 @@ describe("submitLotteryEntriesAction", () => {
     );
   });
 
-  it("rejects alias accounts (suffixed usernames), without writing", async () => {
-    asUser("3A05_sakuten");
+  it("accepts an alias account granted its base account's roles", async () => {
+    asUser("4D11_sakuten", ["Sousakuten", "G4", "ClassD", "Students"]);
+    const state = await submitLotteryEntriesAction(
+      prev,
+      fd({
+        lotteryId: "kaitaku-performance",
+        applicantType: "parent",
+        "choice-sep12-1": "performance-1",
+        "party-sep12": "1",
+      }),
+    );
+
+    expect(state).toEqual({ error: null, success: true, savedSlotCount: 1 });
+    expect(addLotteryEntries).toHaveBeenCalledWith(
+      [
+        expect.objectContaining({
+          username: "4D11_sakuten",
+          slotId: "sep12",
+          firstChoice: "performance-1",
+        }),
+      ],
+      {},
+    );
+  });
+
+  it("rejects a role-less account (e.g. an unprivileged alias), without writing", async () => {
+    asUser("3A05_sakuten", []);
     const state = await submitLotteryEntriesAction(
       prev,
       fd({ lotteryId: "kaitaku-performance", applicantType: "parent" }),


### PR DESCRIPTION
This applies test accounts to be able to get lottery, so this isn't a good decision, but something better than regex match.