### PR TITLE
making the equipment page public

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -260,7 +260,10 @@ export default function Toppage() {
               <p>↓工具貸出サイト、情報伝達用サイトはこちらからアクセス</p>
             </div>
             <div className={styles.linkContainer}>
-              <div className={styles.rentalSite}>
+              <a
+                className={styles.rentalSite}
+                href="https://equipment.2026.kss-it.com"
+              >
                 <p
                   style={{
                     color: "#fff",
@@ -269,10 +272,8 @@ export default function Toppage() {
                   }}
                 >
                   工具貸出サイト
-                  <br />
-                  （Coming Soon）
                 </p>
-              </div>
+              </a>
 
               <div className={styles.informationSite}>
                 <p

--- a/app/top-page.module.css
+++ b/app/top-page.module.css
@@ -286,7 +286,7 @@
   width: 200px;
   padding: 10px 0;
   text-align: center;
-  background-color: #676767;
+  background-color: #469ce2;
   color: #ffffff;
   border-radius: 8px;
   font-size: 1.1rem;

--- a/app/top-page.module.css
+++ b/app/top-page.module.css
@@ -286,7 +286,6 @@
   width: 200px;
   padding: 10px 0;
   text-align: center;
-  background-color: #469ce2;
   color: #ffffff;
   border-radius: 8px;
   font-size: 1.1rem;
@@ -300,6 +299,14 @@
 .informationSite p {
   color: #ffffff;
 }
+
+.rentalSite {
+  background-color: #2a6cca;
+}
+.informationSite {
+  background-color: #676767;
+}
+
 .ceremonyTitle {
   font-size: 4rem;
   font-family: "Yu Mincho", serif;

--- a/content/changelog/0256-changelog.json
+++ b/content/changelog/0256-changelog.json
@@ -1,5 +1,5 @@
 {
-  "title": "making the equipment page public",
-  "description": "TODO",
+  "title": "備品管理サイトの公開",
+  "description": "備品管理サイトへのリンクを公開しました。",
   "credits": ["@rotarymars"]
 }

--- a/content/changelog/0256-changelog.json
+++ b/content/changelog/0256-changelog.json
@@ -1,0 +1,5 @@
+{
+  "title": "making the equipment page public",
+  "description": "TODO",
+  "credits": ["@rotarymars"]
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a link to the equipment management site in the “創作展” section.
  * Updated the equipment rental site card with a blue visual style.

* **Documentation**
  * Added a changelog entry announcing the equipment management site launch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->