### PR TITLE
adding proper description on save

### DIFF
--- a/app/lottery/[lotteryId]/LotteryEntryForm.tsx
+++ b/app/lottery/[lotteryId]/LotteryEntryForm.tsx
@@ -50,6 +50,18 @@ export function LotteryEntryForm({
     submitLotteryEntriesAction,
     INITIAL_STATE,
   );
+  // How many performance slots the SERVER currently holds entries for — what
+  // the 申込状況 banner reports. Seeded from the page's server render and
+  // advanced only when a submit round-trips successfully, so the banner shows
+  // confirmed server state, never an optimistic guess.
+  const [savedSlotCount, setSavedSlotCount] = useState(
+    () => Object.keys(defaultChoices).length,
+  );
+  // Adjusted during render (not in an effect) so a fresh success never paints
+  // a stale banner frame; the equality guard makes it settle immediately.
+  if (state.success && savedSlotCount !== state.savedSlotCount) {
+    setSavedSlotCount(state.savedSlotCount);
+  }
   // Controlled selects so a class picked at one rank can be disabled at the
   // slot's other ranks. Keyed per slot, always RANK_LABELS.length long,
   // "" = no choice at that rank.
@@ -112,6 +124,17 @@ export function LotteryEntryForm({
     <form action={formAction} onSubmit={handleSubmit} className={styles.form}>
       <input type="hidden" name="lotteryId" value={lotteryId} />
       <input type="hidden" name="applicantType" value={applicantType} />
+      {savedSlotCount > 0 ? (
+        <p className={`${styles.submitStatus} ${styles.submitStatusDone}`}>
+          申込済み：{savedSlotCount}件の希望がサーバーに保存されています。
+          {isOpen && "もう一度送信すると内容は上書きされます。"}
+        </p>
+      ) : (
+        <p className={`${styles.submitStatus} ${styles.submitStatusNone}`}>
+          未申込：まだ希望はサーバーに送信されていません。
+          {isOpen && "希望を選んで「希望を送信」を押してください。"}
+        </p>
+      )}
       {slots.map((slot) => {
         const choices = choicesBySlot[slot.id];
         return (
@@ -209,13 +232,13 @@ export function LotteryEntryForm({
       {state.success && (
         <p className={styles.success} role="status">
           {state.savedSlotCount > 0
-            ? `希望を保存しました（${state.savedSlotCount}件）。`
+            ? `送信が完了しました。希望をサーバーに保存しました（${state.savedSlotCount}件）。`
             : "希望をすべて取り消しました。"}
         </p>
       )}
       {isOpen && (
         <button className={styles.button} type="submit" disabled={isPending}>
-          {isPending ? "保存中…" : "希望を保存"}
+          {isPending ? "送信中…" : "希望を送信"}
         </button>
       )}
     </form>

--- a/app/lottery/[lotteryId]/LotteryEntryForm.tsx
+++ b/app/lottery/[lotteryId]/LotteryEntryForm.tsx
@@ -22,6 +22,41 @@ const INITIAL_STATE: LotteryEntryFormState = {
 // bundle.
 const RANK_LABELS = ["第1希望", "第2希望", "第3希望"] as const;
 
+// The whole form as select values, used both as live state and as the
+// server-saved baseline that unsent edits are detected against.
+type FormSnapshot = {
+  // slotId -> choices, always RANK_LABELS.length long, "" = no choice.
+  choices: Record<string, string[]>;
+  // slotId -> 観覧人数 as a select value ("1"/"2").
+  party: Record<string, string>;
+};
+
+function buildChoicesBySlot(
+  slots: readonly LotterySlot[],
+  defaultChoices: Record<string, string[]>,
+): Record<string, string[]> {
+  const choices: Record<string, string[]> = {};
+  for (const slot of slots) {
+    const saved = defaultChoices[slot.id] ?? [];
+    choices[slot.id] = Array.from(
+      { length: RANK_LABELS.length },
+      (_, rankIndex) => saved[rankIndex] ?? "",
+    );
+  }
+  return choices;
+}
+
+function buildPartyBySlot(
+  slots: readonly LotterySlot[],
+  defaultPartySizes: Record<string, number>,
+): Record<string, string> {
+  const party: Record<string, string> = {};
+  for (const slot of slots) {
+    party[slot.id] = String(defaultPartySizes[slot.id] ?? 1);
+  }
+  return party;
+}
+
 type LotteryEntryFormProps = {
   lotteryId: string;
   applicantType: LotteryApplicantType;
@@ -66,25 +101,46 @@ export function LotteryEntryForm({
   // slot's other ranks. Keyed per slot, always RANK_LABELS.length long,
   // "" = no choice at that rank.
   const [choicesBySlot, setChoicesBySlot] = useState<Record<string, string[]>>(
-    () => {
-      const initial: Record<string, string[]> = {};
-      for (const slot of slots) {
-        const saved = defaultChoices[slot.id] ?? [];
-        initial[slot.id] = Array.from(
-          { length: RANK_LABELS.length },
-          (_, rankIndex) => saved[rankIndex] ?? "",
-        );
-      }
-      return initial;
-    },
+    () => buildChoicesBySlot(slots, defaultChoices),
   );
   // 観覧人数 per slot, as select values ("1"/"2").
-  const [partyBySlot, setPartyBySlot] = useState<Record<string, string>>(() => {
-    const initial: Record<string, string> = {};
-    for (const slot of slots) {
-      initial[slot.id] = String(defaultPartySizes[slot.id] ?? 1);
+  const [partyBySlot, setPartyBySlot] = useState<Record<string, string>>(() =>
+    buildPartyBySlot(slots, defaultPartySizes),
+  );
+  // What the SERVER currently holds, as select values — the baseline the
+  // live selects are compared against so the 申込状況 banner can flip to
+  // "未送信の変更あり" the moment an edit diverges from it. Advanced only
+  // when a submit round-trips successfully.
+  const [savedForm, setSavedForm] = useState<FormSnapshot>(() => ({
+    choices: buildChoicesBySlot(slots, defaultChoices),
+    party: buildPartyBySlot(slots, defaultPartySizes),
+  }));
+  // The values captured at dispatch time. On success the server saved exactly
+  // this snapshot — NOT the live selects, which the user may have edited while
+  // the submit was in flight — so this is what gets promoted into savedForm.
+  const [submittedForm, setSubmittedForm] = useState<FormSnapshot | null>(null);
+  // useActionState returns a new state object per completed dispatch, so a
+  // reference change is the "a submit just finished" signal. Same
+  // render-phase-adjustment pattern as savedSlotCount above.
+  const [handledState, setHandledState] = useState(state);
+  if (state !== handledState) {
+    setHandledState(state);
+    if (state.success && submittedForm !== null) {
+      setSavedForm(submittedForm);
+      setSubmittedForm(null);
     }
-    return initial;
+  }
+  // A slot's 観覧人数 is ignored server-side while the slot has no choices,
+  // so a party-size edit alone on a choice-less slot is not an unsent change.
+  const hasUnsentChanges = slots.some((slot) => {
+    const choices = choicesBySlot[slot.id];
+    const saved = savedForm.choices[slot.id];
+    if (choices.some((choice, rankIndex) => choice !== saved[rankIndex])) {
+      return true;
+    }
+    return (
+      choices[0] !== "" && partyBySlot[slot.id] !== savedForm.party[slot.id]
+    );
   });
 
   // React 19 auto-resets a form's DOM fields after a <form action> dispatch.
@@ -96,6 +152,7 @@ export function LotteryEntryForm({
   function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
     const formData = new FormData(event.currentTarget);
+    setSubmittedForm({ choices: choicesBySlot, party: partyBySlot });
     startTransition(() => {
       formAction(formData);
     });
@@ -124,10 +181,15 @@ export function LotteryEntryForm({
     <form action={formAction} onSubmit={handleSubmit} className={styles.form}>
       <input type="hidden" name="lotteryId" value={lotteryId} />
       <input type="hidden" name="applicantType" value={applicantType} />
-      {savedSlotCount > 0 ? (
+      {hasUnsentChanges ? (
+        <p className={`${styles.submitStatus} ${styles.submitStatusDirty}`}>
+          未送信の変更あり：画面で選択した内容はまだサーバーに保存されていません。「希望を送信」を押して保存してください。
+        </p>
+      ) : savedSlotCount > 0 ? (
         <p className={`${styles.submitStatus} ${styles.submitStatusDone}`}>
           申込済み：{savedSlotCount}件の希望がサーバーに保存されています。
-          {isOpen && "申込み内容を変更したい場合は、再度クラスを選択し、「希望を送信」を押してください。"}
+          {isOpen &&
+            "申込み内容を変更したい場合は、再度希望を選択し直し、「希望を送信」を押してください。なお、入力内容の変更は、申込期限まで何度でも可能です。"}
         </p>
       ) : (
         <p className={`${styles.submitStatus} ${styles.submitStatusNone}`}>
@@ -229,7 +291,7 @@ export function LotteryEntryForm({
           {state.error}
         </p>
       )}
-      {state.success && (
+      {state.success && !hasUnsentChanges && (
         <p className={styles.success} role="status">
           {state.savedSlotCount > 0
             ? `送信が完了しました。希望をサーバーに保存しました（${state.savedSlotCount}件）。`

--- a/app/lottery/[lotteryId]/LotteryEntryForm.tsx
+++ b/app/lottery/[lotteryId]/LotteryEntryForm.tsx
@@ -131,7 +131,7 @@ export function LotteryEntryForm({
         </p>
       ) : (
         <p className={`${styles.submitStatus} ${styles.submitStatusNone}`}>
-          未申込：まだ希望はサーバーに送信されていません。
+          未申込：まだ希望はサーバーに送信されていない、もしくは希望がない状態として保存されています。
           {isOpen && "希望を選んで「希望を送信」を押してください。"}
         </p>
       )}

--- a/app/lottery/[lotteryId]/LotteryEntryForm.tsx
+++ b/app/lottery/[lotteryId]/LotteryEntryForm.tsx
@@ -127,7 +127,7 @@ export function LotteryEntryForm({
       {savedSlotCount > 0 ? (
         <p className={`${styles.submitStatus} ${styles.submitStatusDone}`}>
           申込済み：{savedSlotCount}件の希望がサーバーに保存されています。
-          {isOpen && "もう一度送信すると内容は上書きされます。"}
+          {isOpen && "申込み内容を変更したい場合は、再度クラスを選択し、「希望を送信」を押してください。"}
         </p>
       ) : (
         <p className={`${styles.submitStatus} ${styles.submitStatusNone}`}>

--- a/app/lottery/[lotteryId]/page.tsx
+++ b/app/lottery/[lotteryId]/page.tsx
@@ -150,7 +150,7 @@ async function LotteryDetail({
         {availability === "closed" && (
           <p className={styles.closed}>
             申込受付は終了しました。
-            {canApply && "保存済みの希望は以下のとおりです。"}
+            {canApply && "送信済みの希望は以下のとおりです。"}
           </p>
         )}
         {canApply ? (

--- a/app/lottery/lottery.module.css
+++ b/app/lottery/lottery.module.css
@@ -272,7 +272,10 @@
   background: color-mix(in oklch, #237804 8%, var(--background));
 }
 
-.submitStatusNone {
+/* .submitStatusDirty (edits not yet submitted) shares 未申込's amber — both
+   mean "the server does not have what you see; press 送信". */
+.submitStatusNone,
+.submitStatusDirty {
   color: #d46b08;
   border-color: color-mix(in oklch, #d46b08 45%, transparent);
   background: color-mix(in oklch, #d46b08 8%, var(--background));
@@ -322,7 +325,8 @@
     background: color-mix(in oklch, #95de64 10%, var(--background));
   }
 
-  .submitStatusNone {
+  .submitStatusNone,
+  .submitStatusDirty {
     /* Same WCAG AA swap as .closed, on the banner's own tinted background. */
     color: #ffa940;
     border-color: color-mix(in oklch, #ffa940 45%, transparent);

--- a/app/lottery/lottery.module.css
+++ b/app/lottery/lottery.module.css
@@ -254,6 +254,30 @@
   color: #237804;
 }
 
+/* 申込状況 banner — the always-visible answer to "did my application reach
+   the server?" (the transient .success line alone was read as a mere local
+   save and people doubted their submission went through). */
+.submitStatus {
+  font-size: 0.9rem;
+  font-weight: 600;
+  border: 1px solid;
+  border-radius: 8px;
+  padding: 10px 14px;
+  margin: 0;
+}
+
+.submitStatusDone {
+  color: #237804;
+  border-color: color-mix(in oklch, #237804 45%, transparent);
+  background: color-mix(in oklch, #237804 8%, var(--background));
+}
+
+.submitStatusNone {
+  color: #d46b08;
+  border-color: color-mix(in oklch, #d46b08 45%, transparent);
+  background: color-mix(in oklch, #d46b08 8%, var(--background));
+}
+
 .ineligible {
   font-size: 0.9rem;
   color: #d4380d;
@@ -289,6 +313,20 @@
   .closed {
     /* #d46b08 is below WCAG AA contrast on the dark card background. */
     color: #ffa940;
+  }
+
+  .submitStatusDone {
+    /* Same WCAG AA swap as .success, on the banner's own tinted background. */
+    color: #95de64;
+    border-color: color-mix(in oklch, #95de64 45%, transparent);
+    background: color-mix(in oklch, #95de64 10%, var(--background));
+  }
+
+  .submitStatusNone {
+    /* Same WCAG AA swap as .closed, on the banner's own tinted background. */
+    color: #ffa940;
+    border-color: color-mix(in oklch, #ffa940 45%, transparent);
+    background: color-mix(in oklch, #ffa940 10%, var(--background));
   }
 }
 

--- a/content/changelog/0279-changelog.json
+++ b/content/changelog/0279-changelog.json
@@ -1,5 +1,5 @@
 {
-  "title": "adding proper description on save",
-  "description": "TODO",
+  "title": "抽選フォームの修正",
+  "description": "抽選フォームにおける\"希望を保存\"ボタンについて、分かりにくかったため説明を追加しました。",
   "credits": ["@rotarymars"]
 }

--- a/content/changelog/0279-changelog.json
+++ b/content/changelog/0279-changelog.json
@@ -1,0 +1,5 @@
+{
+  "title": "adding proper description on save",
+  "description": "TODO",
+  "credits": ["@rotarymars"]
+}


### PR DESCRIPTION
The button used to say 'save' but it looked like some people couldn't understand that it was saved on the server.
This change introduces a proper description to this.

closes #277

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KSS-IT-Committee/codesmith/2026-event-week-top/pr/279"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786941031&installation_id=147161018&pr_number=279&repository=KSS-IT-Committee%2F2026-event-week-top&return_to=https%3A%2F%2Fgithub.com%2FKSS-IT-Committee%2F2026-event-week-top%2Fpull%2F279&signature=9f1b42dfa9daed36ffec57202adffc2cb1f3ae1b0ad905e4962af2921b512541"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a submission status banner showing whether lottery preferences were successfully sent or are still pending.
  - Status messages now reflect server-confirmed saved entries.
  - Added clearer guidance for open lotteries and previously submitted entries.

- **Improvements**
  - Updated confirmation and button labels to use consistent “send” terminology.
  - Clarified that displayed preferences have been submitted.
  - Added accessible light- and dark-mode styling for submission statuses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->