### PR TITLE
fix of coding style

### DIFF
--- a/app/components/AccountNav/AccountNavLink.tsx
+++ b/app/components/AccountNav/AccountNavLink.tsx
@@ -30,7 +30,16 @@ export function AccountNavLink({
     }
     event.preventDefault();
     const next = encodeURIComponent(window.location.href);
-    window.location.href = `${loginBaseUrl}?next=${next}`;
+    // Resolve against the current origin so the destination is absolute either
+    // way: loginBaseUrl is a cross-origin URL in production (the shared /login
+    // on the namespace apex) but the relative "/login" in local dev and vvps.
+    // Assigning it is a full page load on purpose — the login handoff must
+    // leave this app rather than client-route within it.
+    const target = new URL(
+      `${loginBaseUrl}?next=${next}`,
+      window.location.href,
+    );
+    window.location.assign(target.toString());
   }
 
   const isLoggedIn = username !== null;

--- a/content/changelog/0342-changelog.json
+++ b/content/changelog/0342-changelog.json
@@ -1,0 +1,5 @@
+{
+  "title": "fix of coding style",
+  "description": "TODO",
+  "credits": ["@rotarymars"]
+}

--- a/content/changelog/0342-changelog.json
+++ b/content/changelog/0342-changelog.json
@@ -1,5 +1,5 @@
 {
-  "title": "fix of coding style",
-  "description": "TODO",
+  "title": "内部コードの修正",
+  "description": "ページ内のコードを一部修正しました。これによるページの変更はありません。",
   "credits": ["@rotarymars"]
 }


### PR DESCRIPTION
This fixes the warning that is generated from eslint-config-next 16.3.0

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KSS-IT-Committee/codesmith/2026-event-week-top/pr/342"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788957828&installation_model_id=427714&pr_number=342&repository=KSS-IT-Committee%2F2026-event-week-top&return_to=https%3A%2F%2Fgithub.com%2FKSS-IT-Committee%2F2026-event-week-top%2Fpull%2F342&signature=f286ac17f36e89f9eb2dda452d0ee4080e1a3961ab6c56d40bae8fe0c7e6eaf2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->