### PR TITLE
adding an overlay warning to guide to the proper page

### DIFF
--- a/app/lottery-external/InternalNotice/InternalNotice.module.css
+++ b/app/lottery-external/InternalNotice/InternalNotice.module.css
@@ -1,0 +1,106 @@
+.overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: color-mix(in oklch, #000000 55%, transparent);
+}
+
+.panel {
+  width: 100%;
+  max-width: 460px;
+  border: 1px solid color-mix(in oklch, var(--foreground) 15%, transparent);
+  border-radius: 12px;
+  padding: 28px 24px;
+  background: color-mix(in oklch, var(--foreground) 3%, var(--background));
+  box-shadow: 0 12px 32px color-mix(in oklch, #000000 30%, transparent);
+}
+
+.title {
+  font-size: 1.2rem;
+  font-weight: 700;
+  border-left: 4px solid #0b69eb;
+  padding-left: 10px;
+  margin-bottom: 14px;
+}
+
+.body {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  font-size: 0.9rem;
+  line-height: 1.8;
+  margin-bottom: 20px;
+}
+
+.note {
+  font-size: 0.85rem;
+  color: color-mix(in oklch, var(--foreground) 75%, transparent);
+}
+
+.link {
+  color: #0b69eb;
+  text-decoration: underline;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.primaryAction {
+  display: inline-block;
+  border: 1px solid #0b69eb;
+  border-radius: 8px;
+  padding: 10px 20px;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #ffffff;
+  background: #0b69eb;
+  transition: opacity 0.15s ease;
+}
+
+.primaryAction:hover {
+  opacity: 0.85;
+}
+
+.secondaryAction {
+  border: 1px solid color-mix(in oklch, var(--foreground) 25%, transparent);
+  border-radius: 8px;
+  padding: 10px 20px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--foreground);
+  background: transparent;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.secondaryAction:hover {
+  background: color-mix(in oklch, var(--foreground) 8%, transparent);
+}
+
+@media (prefers-color-scheme: dark) {
+  .link {
+    color: #6ab0ff;
+  }
+}
+
+@media (max-width: 480px) {
+  .panel {
+    padding: 24px 20px;
+  }
+
+  .actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .primaryAction {
+    text-align: center;
+  }
+}

--- a/app/lottery-external/InternalNotice/index.tsx
+++ b/app/lottery-external/InternalNotice/index.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useRef, useState } from "react";
+
+import styles from "./InternalNotice.module.css";
+
+export function InternalNotice() {
+  const [isOpen, setIsOpen] = useState(true);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    closeButtonRef.current?.focus();
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") setIsOpen(false);
+    }
+    document.addEventListener("keydown", handleKeyDown);
+
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      document.body.style.overflow = previousOverflow;
+    };
+  }, [isOpen]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      className={styles.overlay}
+      onClick={() => setIsOpen(false)}
+      role="presentation"
+    >
+      <div
+        aria-describedby="internal-notice-body"
+        aria-labelledby="internal-notice-title"
+        aria-modal="true"
+        className={styles.panel}
+        onClick={(event) => event.stopPropagation()}
+        role="dialog"
+      >
+        <h2 className={styles.title} id="internal-notice-title">
+          このページは外部の方向けです
+        </h2>
+        <div className={styles.body} id="internal-notice-body">
+          <p>
+            生徒・教職員の方は、このページの申し込みフォームではなく
+            <Link className={styles.link} href="/lottery">
+              校内向け申込ページ
+            </Link>
+            からお申し込みください。
+          </p>
+          <p className={styles.note}>
+            保護者の方も、お子様のアカウントでログインのうえ校内向け申込ページからお申し込みいただけます。
+          </p>
+        </div>
+        <div className={styles.actions}>
+          <Link className={styles.primaryAction} href="/lottery">
+            校内向け申込ページへ
+          </Link>
+          <button
+            className={styles.secondaryAction}
+            onClick={() => setIsOpen(false)}
+            ref={closeButtonRef}
+            type="button"
+          >
+            このまま閲覧する
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/lottery-external/InternalNotice/index.tsx
+++ b/app/lottery-external/InternalNotice/index.tsx
@@ -5,9 +5,13 @@ import { useEffect, useRef, useState } from "react";
 
 import styles from "./InternalNotice.module.css";
 
+const FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
 export function InternalNotice() {
   const [isOpen, setIsOpen] = useState(true);
   const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (!isOpen) return;
@@ -15,7 +19,32 @@ export function InternalNotice() {
     closeButtonRef.current?.focus();
 
     function handleKeyDown(event: KeyboardEvent) {
-      if (event.key === "Escape") setIsOpen(false);
+      if (event.key === "Escape") {
+        setIsOpen(false);
+        return;
+      }
+      if (event.key !== "Tab") return;
+
+      const panel = panelRef.current;
+      if (!panel) return;
+      const focusables =
+        panel.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR);
+      if (focusables.length === 0) return;
+
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      const active = document.activeElement;
+
+      if (event.shiftKey && (active === first || !panel.contains(active))) {
+        event.preventDefault();
+        last.focus();
+      } else if (
+        !event.shiftKey &&
+        (active === last || !panel.contains(active))
+      ) {
+        event.preventDefault();
+        first.focus();
+      }
     }
     document.addEventListener("keydown", handleKeyDown);
 
@@ -42,6 +71,7 @@ export function InternalNotice() {
         aria-modal="true"
         className={styles.panel}
         onClick={(event) => event.stopPropagation()}
+        ref={panelRef}
         role="dialog"
       >
         <h2 className={styles.title} id="internal-notice-title">

--- a/app/lottery-external/page.tsx
+++ b/app/lottery-external/page.tsx
@@ -2,8 +2,8 @@ import type { Metadata } from "next";
 import Link from "next/link";
 
 import { FloatingMenu } from "@/app/components/FloatingMenu";
+import { Internal } from "@/app/components/Internal";
 import { TimeGuard } from "@/app/components/TimeGuard";
-import { PartySizeGuide } from "@/app/lottery/[lotteryId]/PartySizeGuide";
 import {
   APPLICATION_PERIOD,
   EXTERNAL_FORM_URL,
@@ -13,7 +13,10 @@ import {
   RESULT_ANNOUNCEMENT,
   RESULT_PAGE_URL,
 } from "@/app/lottery-external/formConfig";
+import { InternalNotice } from "@/app/lottery-external/InternalNotice";
 import styles from "@/app/lottery-external/lottery-external.module.css";
+import { PartySizeGuide } from "@/app/lottery/[lotteryId]/PartySizeGuide";
+import { INTERNAL_ROLES } from "@/lib/access";
 
 /**
  * 外部の方向けの観覧抽選 案内ページ。
@@ -49,6 +52,9 @@ const PERFORMANCE_SLOTS = [
 export default function LotteryExternalPage() {
   return (
     <>
+      <Internal role={INTERNAL_ROLES}>
+        <InternalNotice />
+      </Internal>
       <div className={styles.main}>
         <article className={styles.card}>
           <h1 className={styles.title}>公演観覧抽選（外部の方向け）</h1>

--- a/app/lottery-external/page.tsx
+++ b/app/lottery-external/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { FloatingMenu } from "@/app/components/FloatingMenu";
 import { Internal } from "@/app/components/Internal";
 import { TimeGuard } from "@/app/components/TimeGuard";
+import { PartySizeGuide } from "@/app/lottery/[lotteryId]/PartySizeGuide";
 import {
   APPLICATION_PERIOD,
   EXTERNAL_FORM_URL,
@@ -15,7 +16,6 @@ import {
 } from "@/app/lottery-external/formConfig";
 import { InternalNotice } from "@/app/lottery-external/InternalNotice";
 import styles from "@/app/lottery-external/lottery-external.module.css";
-import { PartySizeGuide } from "@/app/lottery/[lotteryId]/PartySizeGuide";
 import { INTERNAL_ROLES } from "@/lib/access";
 
 /**

--- a/content/changelog/0346-changelog.json
+++ b/content/changelog/0346-changelog.json
@@ -1,0 +1,5 @@
+{
+  "title": "adding an overlay warning to guide to the proper page",
+  "description": "TODO",
+  "credits": ["@rotarymars"]
+}

--- a/content/changelog/0346-changelog.json
+++ b/content/changelog/0346-changelog.json
@@ -1,5 +1,5 @@
 {
-  "title": "adding an overlay warning to guide to the proper page",
-  "description": "TODO",
+  "title": "外部抽選ページの改善",
+  "description": "外部の方に向けた抽選ページにて、生徒・教員が開いたときに表示される案内ダイアログを追加しました。",
   "credits": ["@rotarymars"]
 }


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KSS-IT-Committee/codesmith/2026-event-week-top/pr/346"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789015862&installation_model_id=427714&pr_number=346&repository=KSS-IT-Committee%2F2026-event-week-top&return_to=https%3A%2F%2Fgithub.com%2FKSS-IT-Committee%2F2026-event-week-top%2Fpull%2F346&signature=235c0d10de0b679f4c7b44d6f3a2cf5397fbb2e9bc5be52242949b6f5f6c4750"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an informational notice modal to the external lottery page for students and teachers.
  * Provided a link to the internal application and an option to continue viewing the public page.
  * Added dismissal via outside click, Escape, or the continue button.
  * Added responsive styling, accessibility-focused focus handling, and dark-mode link support.

* **Documentation**
  * Added a Japanese changelog entry describing the updated external lottery experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->