### PR TITLE
added result page

### DIFF
--- a/app/lottery-external/formConfig.ts
+++ b/app/lottery-external/formConfig.ts
@@ -63,9 +63,14 @@ export const RESULT_ANNOUNCEMENT: string | null = "8月27日（木）以降";
 /**
  * 当選者一覧ページのURL（抽選後に公開する場合）。
  * 未公開のうちは null にしておくと、当選発表の節にリンクが出ません。
- * 例: "/lottery-external/results" や外部URL。
+ *
+ * 外部の方向けの当落発表は、このアプリではなく創作展トップ
+ * （2026-sousakuten-top）が持っています。抽選番号で検索できる
+ * /lottery ページがそれで、当選番号の一覧もそこにあります。
+ * 別アプリなので相対パスでは届きません — 絶対URLで書いてください。
  */
-export const RESULT_PAGE_URL: string | null = null;
+export const RESULT_PAGE_URL: string | null =
+  "https://sousakuten-top.2026.kss-it.com/lottery";
 
 /**
  * ページ上部に出すお知らせ（追記）。新しいものを先頭に足してください。

--- a/content/changelog/0371-changelog.json
+++ b/content/changelog/0371-changelog.json
@@ -1,5 +1,5 @@
 {
-  "title": "added result page",
-  "description": "TODO",
+  "title": "抽選結果へのリンクを追加",
+  "description": "外部の方の抽選結果へのリンクを追加しました。",
   "credits": ["@rotarymars"]
 }

--- a/content/changelog/0371-changelog.json
+++ b/content/changelog/0371-changelog.json
@@ -1,0 +1,5 @@
+{
+  "title": "added result page",
+  "description": "TODO",
+  "credits": ["@rotarymars"]
+}


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KSS-IT-Committee/codesmith/2026-event-week-top/pr/371"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790951236&installation_model_id=427714&pr_number=371&repository=KSS-IT-Committee%2F2026-event-week-top&return_to=https%3A%2F%2Fgithub.com%2FKSS-IT-Committee%2F2026-event-week-top%2Fpull%2F371&signature=0db967728b59308fc1cd318827aa1f9c44c614997f06e1c0bb8a653aa6e429fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a direct link to the externally hosted lottery results page.
  - Lottery results can now be accessed through the configured external results destination.

- **Documentation**
  - Updated the changelog to announce the availability of external lottery results links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->