### PR TITLE
student view

### DIFF
--- a/content/changelog/0416-changelog.json
+++ b/content/changelog/0416-changelog.json
@@ -1,0 +1,5 @@
+{
+  "title": "student view",
+  "description": "TODO",
+  "credits": ["@rotarymars"]
+}

--- a/content/changelog/0416-changelog.json
+++ b/content/changelog/0416-changelog.json
@@ -1,5 +1,5 @@
 {
-  "title": "student view",
-  "description": "TODO",
+  "title": "第五公演の抽選を追加",
+  "description": "第五公演の抽選を追加しました。",
   "credits": ["@rotarymars"]
 }

--- a/lib/lotteries.test.ts
+++ b/lib/lotteries.test.ts
@@ -495,6 +495,62 @@ describe("describeApplicationDeadline", () => {
     );
   });
 
+  it("names the hour when the window shuts mid-day", () => {
+    // A date alone would promise a whole day the form is already shut for,
+    // so a non-midnight bound is stated as the instant it closes — not as
+    // the last accepted millisecond, which would read 08:59.
+    const fixture = {
+      ...kaitaku,
+      closesAt: new Date("2026-09-13T09:00:00+09:00"),
+    };
+    expect(describeApplicationDeadline(fixture)).toBe(
+      "2026年9月13日（日）09:00まで",
+    );
+  });
+
+  it("judges midnight in JST, not in the server's timezone", () => {
+    // 15:00Z IS JST midnight — so this keeps the date-only shape, and names
+    // the last JST day accepted. Production does not run in JST, so the
+    // judgement must follow the festival's clock, never the server's.
+    expect(
+      describeApplicationDeadline({
+        ...kaitaku,
+        closesAt: new Date("2026-08-30T15:00:00Z"),
+      }),
+    ).toBe("2026年8月30日（日）まで");
+    // …and a bound that is midnight only in UTC still names its hour.
+    expect(
+      describeApplicationDeadline({
+        ...kaitaku,
+        closesAt: new Date("2026-08-31T00:00:00Z"),
+      }),
+    ).toBe("2026年8月31日（月）09:00まで");
+  });
+
+  it("states a time for every mid-day deadline now configured", () => {
+    // Behaviour, not the value: whatever instants the committee sets, a
+    // lottery that closes mid-day must never be rendered date-only. Pins the
+    // string the pages interpolate verbatim (「申込期限は{deadline}です。」).
+    for (const lottery of LOTTERIES) {
+      const described = describeApplicationDeadline(lottery);
+      if (lottery.closesAt === null) {
+        expect(described).toBeNull();
+        continue;
+      }
+      const isMidnightBound =
+        new Intl.DateTimeFormat("ja-JP", {
+          timeZone: "Asia/Tokyo",
+          hourCycle: "h23",
+          hour: "2-digit",
+          minute: "2-digit",
+          second: "2-digit",
+        }).format(lottery.closesAt) === "00:00:00";
+      expect(described).toMatch(
+        isMidnightBound ? /）まで$/ : /）\d{2}:\d{2}まで$/,
+      );
+    }
+  });
+
   it("returns null when no deadline is configured", () => {
     expect(describeApplicationDeadline({ ...kaitaku, closesAt: null })).toBe(
       null,

--- a/lib/lotteries.test.ts
+++ b/lib/lotteries.test.ts
@@ -237,19 +237,12 @@ describe("LOTTERIES registry", () => {
     expect(studentViewing.acts).toEqual(sousaku.acts);
   });
 
-  it("restricts 生徒観覧 to 本人 entries from grade 5-6 classes, no staff", () => {
+  it("opens 生徒観覧 to every class as 本人 entries only, no staff", () => {
+    // The acts are the 創作部門 plays, but the audience is the whole school —
+    // the two lists are deliberately unrelated.
     expect(studentViewing.applicantTypes).toEqual(["student"]);
     expect(studentViewing.canStaffApply).toBe(false);
-    expect(studentViewing.eligibleClasses).toEqual([
-      "5A",
-      "5B",
-      "5C",
-      "5D",
-      "6A",
-      "6B",
-      "6C",
-      "6D",
-    ]);
+    expect(studentViewing.eligibleClasses).toEqual([...CLASSNAMES]);
   });
 
   it("carries the important parent-facing notes for both lotteries", () => {
@@ -411,12 +404,9 @@ describe("isEligibleForLottery", () => {
     expect(isEligibleForLottery(sousaku, studentRoles("6D"))).toBe(true);
   });
 
-  it("limits 生徒観覧 to grade 5-6 students", () => {
-    expect(isEligibleForLottery(studentViewing, studentRoles("5A"))).toBe(true);
+  it("accepts every grade's students for 生徒観覧, but no staff", () => {
+    expect(isEligibleForLottery(studentViewing, studentRoles("1A"))).toBe(true);
     expect(isEligibleForLottery(studentViewing, studentRoles("6D"))).toBe(true);
-    expect(isEligibleForLottery(studentViewing, studentRoles("4D"))).toBe(
-      false,
-    );
     expect(isEligibleForLottery(studentViewing, TEACHER_ROLES)).toBe(false);
   });
 });
@@ -450,10 +440,10 @@ describe("canApplyToLottery", () => {
 
   it("takes only 本人 entries for 生徒観覧, never 保護者", () => {
     expect(
-      canApplyToLottery(studentViewing, studentRoles("5A"), "student"),
+      canApplyToLottery(studentViewing, studentRoles("1A"), "student"),
     ).toBe(true);
     expect(
-      canApplyToLottery(studentViewing, studentRoles("5A"), "parent"),
+      canApplyToLottery(studentViewing, studentRoles("1A"), "parent"),
     ).toBe(false);
   });
 });

--- a/lib/lotteries.test.ts
+++ b/lib/lotteries.test.ts
@@ -43,6 +43,7 @@ function mustGetLottery(lotteryId: string): Lottery {
 
 const kaitaku = mustGetLottery("kaitaku-performance");
 const sousaku = mustGetLottery("sousaku-performance");
+const studentViewing = mustGetLottery("sousaku-student-viewing");
 
 describe("LOTTERIES registry", () => {
   it("has unique lottery ids", () => {
@@ -66,9 +67,10 @@ describe("LOTTERIES registry", () => {
   // The exact dates are operations, not behavior — they change as the event
   // approaches (and get toggled to preview UI states), so only the presence
   // of a deadline is pinned here.
-  it("has an application deadline configured for both lotteries", () => {
-    expect(kaitaku.closesAt).toBeInstanceOf(Date);
-    expect(sousaku.closesAt).toBeInstanceOf(Date);
+  it("has an application deadline configured for every lottery", () => {
+    for (const lottery of LOTTERIES) {
+      expect(lottery.closesAt).toBeInstanceOf(Date);
+    }
   });
 
   it("asks kaitaku parents one question per festival day: rank the 8 performances", () => {
@@ -218,6 +220,36 @@ describe("LOTTERIES registry", () => {
     expect(sousaku.applicantTypes).toEqual(["student", "parent"]);
     expect(sousaku.canStaffApply).toBe(true);
     expect(sousaku.eligibleClasses).toEqual([...CLASSNAMES]);
+  });
+
+  it("asks 生徒観覧 one question: which class play at the 2nd day's 第五公演", () => {
+    // 創作部門's extra student-only performance: one slot, and the slot itself
+    // carries the clock, exactly like the other 創作部門 slots.
+    expect(studentViewing.slots).toEqual([
+      {
+        id: "sep13-slot-5",
+        label: "9月13日（日）第五公演",
+        time: "15:45～17:00",
+        startsAt: new Date("2026-09-13T15:45:00+09:00"),
+      },
+    ]);
+    // The very same eight class plays the 創作部門 lottery offers.
+    expect(studentViewing.acts).toEqual(sousaku.acts);
+  });
+
+  it("restricts 生徒観覧 to 本人 entries from grade 5-6 classes, no staff", () => {
+    expect(studentViewing.applicantTypes).toEqual(["student"]);
+    expect(studentViewing.canStaffApply).toBe(false);
+    expect(studentViewing.eligibleClasses).toEqual([
+      "5A",
+      "5B",
+      "5C",
+      "5D",
+      "6A",
+      "6B",
+      "6C",
+      "6D",
+    ]);
   });
 
   it("carries the important parent-facing notes for both lotteries", () => {
@@ -378,6 +410,15 @@ describe("isEligibleForLottery", () => {
     expect(isEligibleForLottery(sousaku, studentRoles("1A"))).toBe(true);
     expect(isEligibleForLottery(sousaku, studentRoles("6D"))).toBe(true);
   });
+
+  it("limits 生徒観覧 to grade 5-6 students", () => {
+    expect(isEligibleForLottery(studentViewing, studentRoles("5A"))).toBe(true);
+    expect(isEligibleForLottery(studentViewing, studentRoles("6D"))).toBe(true);
+    expect(isEligibleForLottery(studentViewing, studentRoles("4D"))).toBe(
+      false,
+    );
+    expect(isEligibleForLottery(studentViewing, TEACHER_ROLES)).toBe(false);
+  });
 });
 
 describe("canApplyToLottery", () => {
@@ -405,6 +446,15 @@ describe("canApplyToLottery", () => {
     expect(canApplyToLottery(kaitaku, studentRoles("5A"), "parent")).toBe(
       false,
     );
+  });
+
+  it("takes only 本人 entries for 生徒観覧, never 保護者", () => {
+    expect(
+      canApplyToLottery(studentViewing, studentRoles("5A"), "student"),
+    ).toBe(true);
+    expect(
+      canApplyToLottery(studentViewing, studentRoles("5A"), "parent"),
+    ).toBe(false);
   });
 });
 

--- a/lib/lotteries.ts
+++ b/lib/lotteries.ts
@@ -261,11 +261,13 @@ export const LOTTERIES: readonly Lottery[] = [
     // 生徒観覧 — 創作部門 stages a fifth performance on the second festival
     // day only (15:45～17:00), for the school's own students instead of
     // outside visitors. Same class plays as sousaku-performance, so the acts
-    // are the same; one performance, so exactly one slot.
+    // are the same; one performance, so exactly one slot. Note the asymmetry:
+    // the acts are the 創作部門 (5・6年) plays, but the AUDIENCE is the whole
+    // student body — eligibleClasses and acts are unrelated lists.
     id: "sousaku-student-viewing",
     title: "生徒観覧（２日目第五公演）",
     description:
-      "9月13日（日）の生徒観覧時間＝創作部門 第五公演（15:45～17:00）の観覧抽選です。5・6年生の生徒本人が対象で、観たいクラスを第1〜第3希望まで選べます。",
+      "9月13日（日）の生徒観覧時間＝創作部門 第五公演（15:45～17:00）の観覧抽選です。全学年の生徒本人が対象で、創作部門（5・6年生）のクラス劇のうち観たいクラスを第1〜第3希望まで選べます。",
     notes: [
       "第五公演は2日目（9月13日）のみ、帰りのSHRのあと 15:45～17:00 に行われます。",
       "申込は9月13日（日）7:00で締め切ります。",
@@ -275,7 +277,9 @@ export const LOTTERIES: readonly Lottery[] = [
     ],
     // 生徒観覧: students only — no 保護者 tab, and staff do not attend it.
     applicantTypes: ["student"],
-    eligibleClasses: SOUSAKU_CLASSES,
+    // Every class in the school, 1A–6D: the 創作部門 students are the ones
+    // performing, but every grade watches.
+    eligibleClasses: [...CLASSNAMES],
     canStaffApply: false,
     acts: SOUSAKU_CLASSES.map(actForClass),
     slots: [

--- a/lib/lotteries.ts
+++ b/lib/lotteries.ts
@@ -270,7 +270,6 @@ export const LOTTERIES: readonly Lottery[] = [
       "9月13日（日）の生徒観覧時間＝創作部門 第五公演（15:45～17:00）の観覧抽選です。全学年の生徒本人が対象で、創作部門（5・6年生）のクラス劇のうち観たいクラスを第1〜第3希望まで選べます。",
     notes: [
       "第五公演は2日目（9月13日）のみ、帰りのSHRのあと 15:45～17:00 に行われます。",
-      "申込は9月13日（日）9:00で締め切ります。",
       "当選したら、帰りのSHRのあとそのクラスの教室へ向かってください。",
       "6年生のクラス劇は、各HR教室での上演のほか、別教室での配信も予定しています。",
       "申込は生徒本人のアカウントから、１アカウントにつき１件です。",
@@ -294,8 +293,7 @@ export const LOTTERIES: readonly Lottery[] = [
     // Exclusive bound, and — unlike the other two — not a midnight one: the
     // vote is collected during the festival itself, so it shuts at 9:00 JST on
     // the second morning, well before the 15:45 performance.
-    // describeApplicationDeadline() renders the DATE only, so the hour is
-    // spelled out in `notes` above as well.
+    // describeApplicationDeadline() states the hour for a bound like this.
     closesAt: new Date("2026-09-13T09:00:00+09:00"),
     // No announcement time fixed yet. Deny-by-default means the draw can be
     // loaded into `lottery_results` the night before without leaking a thing;
@@ -497,12 +495,36 @@ export function describeTicketTransferDeadline(
   );
 }
 
-// 「2026年8月30日（日）まで」 — the last day applications are accepted, or
-// null when no deadline is configured. Derived from the exclusive closesAt
-// bound and rendered in JST, so the pages can never disagree with the
-// enforced window (or with what the parent letter announced).
+// Whether an instant lands exactly on JST midnight — the shape of every
+// "the whole of that day is accepted" bound (closesAt is exclusive, so
+// 8月26日00:00 means 8月25日まで). Any other instant is a mid-day cutoff.
+function isJstMidnight(instant: Date): boolean {
+  const clock = new Intl.DateTimeFormat("ja-JP", {
+    timeZone: "Asia/Tokyo",
+    hourCycle: "h23",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  }).format(instant);
+  return clock === "00:00:00" && instant.getTime() % 1000 === 0;
+}
+
+// 「2026年8月30日（日）まで」, or 「2026年9月13日（日）09:00まで」 when the
+// window shuts mid-day — the deadline as the pages state it, or null when
+// none is configured. Derived from the exclusive closesAt bound and rendered
+// in JST, so the pages can never disagree with the enforced window (or with
+// what the parent letter announced).
+//
+// Two shapes, because a date alone is only honest for a midnight bound. A
+// cutoff at 09:00 rendered as 「9月13日まで」 would promise a whole day the
+// form is already shut for, so those name their hour; the instant shown is
+// closesAt itself (the moment it shuts), not the last accepted millisecond,
+// which would read as the baffling 08:59.
 export function describeApplicationDeadline(lottery: Lottery): string | null {
   if (lottery.closesAt === null) return null;
+  if (!isJstMidnight(lottery.closesAt)) {
+    return `${describeJstDateTime(lottery.closesAt)}まで`;
+  }
   const lastIncludedInstant = new Date(lottery.closesAt.getTime() - 1);
   const date = new Intl.DateTimeFormat("ja-JP", {
     timeZone: "Asia/Tokyo",

--- a/lib/lotteries.ts
+++ b/lib/lotteries.ts
@@ -257,6 +257,47 @@ export const LOTTERIES: readonly Lottery[] = [
     closesAt: new Date("2026-08-26T00:00:00+09:00"),
     resultsAnnouncedAt: new Date("2026-08-27T12:30:00+09:00"),
   },
+  {
+    // 生徒観覧 — 創作部門 stages a fifth performance on the second festival
+    // day only (15:45～17:00), for the school's own students instead of
+    // outside visitors. Same class plays as sousaku-performance, so the acts
+    // are the same; one performance, so exactly one slot.
+    id: "sousaku-student-viewing",
+    title: "生徒観覧（２日目第五公演）",
+    description:
+      "9月13日（日）の生徒観覧時間＝創作部門 第五公演（15:45～17:00）の観覧抽選です。5・6年生の生徒本人が対象で、観たいクラスを第1〜第3希望まで選べます。",
+    notes: [
+      "第五公演は2日目（9月13日）のみ、帰りのSHRのあと 15:45～17:00 に行われます。",
+      "申込は9月13日（日）7:00で締め切ります。",
+      "当選したら、帰りのSHRのあとそのクラスの教室へ向かってください。",
+      "6年生のクラス劇は、各HR教室での上演のほか、別教室での配信も予定しています。",
+      "申込は生徒本人のアカウントから、１アカウントにつき１件です。",
+    ],
+    // 生徒観覧: students only — no 保護者 tab, and staff do not attend it.
+    applicantTypes: ["student"],
+    eligibleClasses: SOUSAKU_CLASSES,
+    canStaffApply: false,
+    acts: SOUSAKU_CLASSES.map(actForClass),
+    slots: [
+      {
+        id: "sep13-slot-5",
+        label: "9月13日（日）第五公演",
+        time: "15:45～17:00",
+        startsAt: new Date("2026-09-13T15:45:00+09:00"),
+      },
+    ],
+    opensAt: new Date("2026-09-12T16:00:00+09:00"),
+    // Exclusive bound, and — unlike the other two — not a midnight one: the
+    // vote is collected during the festival itself, so it shuts at 7:00 JST on
+    // the second morning, well before the 15:45 performance.
+    // describeApplicationDeadline() renders the DATE only, so the hour is
+    // spelled out in `notes` above as well.
+    closesAt: new Date("2026-09-13T07:00:00+09:00"),
+    // No announcement time fixed yet. Deny-by-default means the draw can be
+    // loaded into `lottery_results` the night before without leaking a thing;
+    // set an instant here when the committee names one.
+    resultsAnnouncedAt: null,
+  },
 ];
 
 // "student" reads 本人 (not 生徒本人): staff accounts also apply through it

--- a/lib/lotteries.ts
+++ b/lib/lotteries.ts
@@ -270,7 +270,7 @@ export const LOTTERIES: readonly Lottery[] = [
       "9月13日（日）の生徒観覧時間＝創作部門 第五公演（15:45～17:00）の観覧抽選です。全学年の生徒本人が対象で、創作部門（5・6年生）のクラス劇のうち観たいクラスを第1〜第3希望まで選べます。",
     notes: [
       "第五公演は2日目（9月13日）のみ、帰りのSHRのあと 15:45～17:00 に行われます。",
-      "申込は9月13日（日）7:00で締め切ります。",
+      "申込は9月13日（日）9:00で締め切ります。",
       "当選したら、帰りのSHRのあとそのクラスの教室へ向かってください。",
       "6年生のクラス劇は、各HR教室での上演のほか、別教室での配信も予定しています。",
       "申込は生徒本人のアカウントから、１アカウントにつき１件です。",
@@ -292,11 +292,11 @@ export const LOTTERIES: readonly Lottery[] = [
     ],
     opensAt: new Date("2026-09-12T16:00:00+09:00"),
     // Exclusive bound, and — unlike the other two — not a midnight one: the
-    // vote is collected during the festival itself, so it shuts at 7:00 JST on
+    // vote is collected during the festival itself, so it shuts at 9:00 JST on
     // the second morning, well before the 15:45 performance.
     // describeApplicationDeadline() renders the DATE only, so the hour is
     // spelled out in `notes` above as well.
-    closesAt: new Date("2026-09-13T07:00:00+09:00"),
+    closesAt: new Date("2026-09-13T09:00:00+09:00"),
     // No announcement time fixed yet. Deny-by-default means the draw can be
     // loaded into `lottery_results` the night before without leaking a thing;
     // set an instant here when the committee names one.


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KSS-IT-Committee/codesmith/2026-event-week-top/pr/416"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791785752&installation_model_id=427714&pr_number=416&repository=KSS-IT-Committee%2F2026-event-week-top&return_to=https%3A%2F%2Fgithub.com%2FKSS-IT-Committee%2F2026-event-week-top%2Fpull%2F416&signature=32422d8cd5df2b87068617402072861de5272e2f2819dd57ca7eff729424d456"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a student-only lottery for the fifth performance of the 創作部門.
  * Open to students across all grades, with one available slot.
  * Applications remain open until 9:00 AM on the second festival day.
  * Added a changelog announcement for the new lottery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->